### PR TITLE
Fixed issues with digitizer type

### DIFF
--- a/include/TCSM.h
+++ b/include/TCSM.h
@@ -25,7 +25,7 @@
 #include "TChannel.h"
 #include "TDetector.h"
 #include "TCSMHit.h"
-#include "TMnemonic.h"
+#include "TGRSIMnemonic.h"
 
 class TCSM : public TDetector {
 public:
@@ -44,19 +44,19 @@ public:
    void BuildHits() override;
 
 private:
-   std::map<int16_t, std::vector<std::vector<std::vector<std::pair<TFragment, TMnemonic>>>>> fFragments; //!<!
+   std::map<int16_t, std::vector<std::vector<std::vector<std::pair<TFragment, TGRSIMnemonic>>>>> fFragments; //!<!
    double               fAlmostEqualWindow;
 
    static int fCfdBuildDiff; //!<! largest acceptable time difference between events (clock ticks)  (50 ns)
 
-   void BuildVH(std::vector<std::vector<std::pair<TFragment, TMnemonic>>>&, std::vector<TDetectorHit*>&);
+   void BuildVH(std::vector<std::vector<std::pair<TFragment, TGRSIMnemonic>>>&, std::vector<TDetectorHit*>&);
    void BuilddEE(std::vector<std::vector<TDetectorHit*>>&, std::vector<TDetectorHit*>&);
    void OldBuilddEE(std::vector<TDetectorHit*>&, std::vector<TDetectorHit*>&, std::vector<TDetectorHit*>&);
    void MakedEE(std::vector<TDetectorHit*>& DHitVec, std::vector<TDetectorHit*>& EHitVec, std::vector<TDetectorHit*>& BuiltHits);
-   TCSMHit* MakeHit(std::pair<TFragment, TMnemonic>&, std::pair<TFragment, TMnemonic>&);
-   TCSMHit* MakeHit(std::vector<std::pair<TFragment, TMnemonic>>&, std::vector<std::pair<TFragment, TMnemonic>>&);
+   TCSMHit* MakeHit(std::pair<TFragment, TGRSIMnemonic>&, std::pair<TFragment, TGRSIMnemonic>&);
+   TCSMHit* MakeHit(std::vector<std::pair<TFragment, TGRSIMnemonic>>&, std::vector<std::pair<TFragment, TGRSIMnemonic>>&);
    TCSMHit* CombineHits(TDetectorHit*, TDetectorHit*);
-   void    RecoverHit(char, std::pair<TFragment, TMnemonic>&, std::vector<TDetectorHit*>&);
+   void    RecoverHit(char, std::pair<TFragment, TGRSIMnemonic>&, std::vector<TDetectorHit*>&);
    bool    AlmostEqual(int, int);
    bool    AlmostEqual(double, double);
 

--- a/include/TGRSIMnemonic.h
+++ b/include/TGRSIMnemonic.h
@@ -6,6 +6,8 @@
 #include "Globals.h"
 #include "TClass.h"
 
+enum class EDigitizer : char { kDefault, kGRF16, kGRF4G, kTIG10, kTIG64, kCaen };
+
 class TGRSIMnemonic : public TMnemonic {
 public:
    TGRSIMnemonic() : TMnemonic() { Clear(); }
@@ -46,13 +48,12 @@ public:
 		kTdrPlastic,
 		kClear            //28
    };
-   enum class EDigitizer { kDefault, kGRF16, kGRF4G, kTIG10, kTIG64, kCaen };
 
    ESystem   System() const { return fSystem; }
 
    void Parse(std::string* name) override;
 
-   static EDigitizer EnumerateDigitizer(std::string name);
+   void EnumerateDigitizer(TPriorityValue<std::string>& digitizerName, TPriorityValue<EDigitizer>& digitizerType) override;
 
 	TClass* GetClassType() const override;
    void Print(Option_t* opt = "") const override;

--- a/libraries/TGRSIAnalysis/TCSM/TCSM.cxx
+++ b/libraries/TGRSIAnalysis/TCSM/TCSM.cxx
@@ -51,11 +51,11 @@ void TCSM::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel* c
    // if this is the first time we got this detector number we make a new vector (of a vector) of fragments
    if(fFragments.find(chan->GetMnemonic()->ArrayPosition()) == fFragments.end()) {
       fFragments[chan->GetMnemonic()->ArrayPosition()].resize(
-         2, std::vector<std::vector<std::pair<TFragment, TMnemonic>>>(2));
+         2, std::vector<std::vector<std::pair<TFragment, TGRSIMnemonic>>>(2));
    }
 
    fFragments[chan->GetMnemonic()->ArrayPosition()][type][orientation].push_back(
-      std::make_pair(*frag, *(chan->GetMnemonic())));
+      std::make_pair(*frag, *static_cast<const TGRSIMnemonic*>(chan->GetMnemonic())));
 }
 
 void TCSM::BuildHits()
@@ -128,7 +128,7 @@ TVector3 TCSM::GetPosition(int detector, char pos, int horizontalstrip, int vert
    return Pos;
 }
 
-void TCSM::BuildVH(std::vector<std::vector<std::pair<TFragment, TMnemonic>>>& strips, std::vector<TDetectorHit*>& hitVector)
+void TCSM::BuildVH(std::vector<std::vector<std::pair<TFragment, TGRSIMnemonic>>>& strips, std::vector<TDetectorHit*>& hitVector)
 {
    /// Build hits from horizontal (index = 0) and vertical (index = 1) strips into the hitVector
    if(strips[0].empty() && strips[1].empty()) {
@@ -194,7 +194,7 @@ void TCSM::BuildVH(std::vector<std::vector<std::pair<TFragment, TMnemonic>>>& st
    }
 }
 
-TCSMHit* TCSM::MakeHit(std::pair<TFragment, TMnemonic>& h, std::pair<TFragment, TMnemonic>& v)
+TCSMHit* TCSM::MakeHit(std::pair<TFragment, TGRSIMnemonic>& h, std::pair<TFragment, TGRSIMnemonic>& v)
 {
    TCSMHit* csmHit = new TCSMHit;
 
@@ -238,8 +238,8 @@ TCSMHit* TCSM::MakeHit(std::pair<TFragment, TMnemonic>& h, std::pair<TFragment, 
    return csmHit;
 }
 
-TCSMHit* TCSM::MakeHit(std::vector<std::pair<TFragment, TMnemonic>>& hhV,
-                      std::vector<std::pair<TFragment, TMnemonic>>& vvV)
+TCSMHit* TCSM::MakeHit(std::vector<std::pair<TFragment, TGRSIMnemonic>>& hhV,
+                      std::vector<std::pair<TFragment, TGRSIMnemonic>>& vvV)
 {
    TCSMHit* csmHit = new TCSMHit;
 
@@ -518,7 +518,7 @@ void TCSM::OldBuilddEE(std::vector<TDetectorHit*>& DHitVec, std::vector<TDetecto
    }
 }
 
-void TCSM::RecoverHit(char orientation, std::pair<TFragment, TMnemonic>& hit, std::vector<TDetectorHit*>& hits)
+void TCSM::RecoverHit(char orientation, std::pair<TFragment, TGRSIMnemonic>& hit, std::vector<TDetectorHit*>& hits)
 {
    if(!RECOVERHITS) {
       return;

--- a/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
@@ -48,21 +48,21 @@ Double_t TGRSIDetectorHit::GetTime(const ETimeFlag&, Option_t*) const
       Error("GetTime", "No TChannel exists for address 0x%08x", GetAddress());
       return SetTime(10. * (static_cast<Double_t>((GetTimeStamp()) + gRandom->Uniform())));
    }
-   switch(static_cast<TGRSIMnemonic::EDigitizer>(channel->GetDigitizerType())) {
+   switch(static_cast<EDigitizer>(channel->GetDigitizerType())) {
 		Double_t dTime;
-		case TGRSIMnemonic::EDigitizer::kGRF16:
+		case EDigitizer::kGRF16:
 		dTime = (GetTimeStamp() & (~0x3ffff)) * 10. +
 		channel->CalibrateCFD((GetCfd() + gRandom->Uniform()) / 1.6); // CFD is in 10/16th of a nanosecond
 		return SetTime(dTime - 10. * (channel->GetTZero(GetEnergy())));
-		case TGRSIMnemonic::EDigitizer::kGRF4G:
+		case EDigitizer::kGRF4G:
 		dTime = GetTimeStamp() * 10. + channel->CalibrateCFD((fCfd >> 22) + ((fCfd & 0x3fffff) + gRandom->Uniform()) / 256.);
 		return SetTime(dTime - 10. * (channel->GetTZero(GetEnergy())));
-		case TGRSIMnemonic::EDigitizer::kTIG10:
+		case EDigitizer::kTIG10:
 		dTime = (GetTimeStamp() & (~0x7fffff)) * 10. +
 		channel->CalibrateCFD((GetCfd() + gRandom->Uniform()) / 1.6); // CFD is in 10/16th of a nanosecond
 		//channel->CalibrateCFD((GetCfd() & (~0xf) + gRandom->Uniform()) / 1.6); // PBender suggests this.
 		return SetTime(dTime - 10. * (channel->GetTZero(GetEnergy())));
-      case TGRSIMnemonic::EDigitizer::kCaen:
+      case EDigitizer::kCaen:
       //10 bit CFD for 0-2ns => divide by 512
       dTime = GetTimeStamp() * 10. + channel->CalibrateCFD((GetCfd() + gRandom->Uniform()) / 512.);
       return SetTime(dTime - 10. * (channel->GetTZero(GetEnergy())));

--- a/libraries/TGRSIAnalysis/TGenericDetector/TGenericDetector.cxx
+++ b/libraries/TGRSIAnalysis/TGenericDetector/TGenericDetector.cxx
@@ -1,5 +1,4 @@
 #include "TGenericDetector.h"
-#include "TMnemonic.h"
 
 #include "TClass.h"
 #include <cmath>

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffinBgo.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffinBgo.cxx
@@ -7,7 +7,6 @@
 #include "TRandom.h"
 #include "TMath.h"
 #include "TInterpreter.h"
-#include "TMnemonic.h"
 
 #include "TGRSIOptions.h"
 

--- a/libraries/TGRSIAnalysis/TLaBr/TLaBrBgo.cxx
+++ b/libraries/TGRSIAnalysis/TLaBr/TLaBrBgo.cxx
@@ -7,7 +7,6 @@
 #include "TRandom.h"
 #include "TMath.h"
 #include "TInterpreter.h"
-#include "TMnemonic.h"
 
 #include "TGRSIOptions.h"
 

--- a/libraries/TGRSIFormat/TGRSIMnemonic.cxx
+++ b/libraries/TGRSIFormat/TGRSIMnemonic.cxx
@@ -86,26 +86,25 @@ void TGRSIMnemonic::EnumerateSystem()
    }
 }
 
-TGRSIMnemonic::EDigitizer TGRSIMnemonic::EnumerateDigitizer(std::string name)
+void TGRSIMnemonic::EnumerateDigitizer(TPriorityValue<std::string>& digitizerName, TPriorityValue<EDigitizer>& digitizerType)
 {
+	std::string name = digitizerName.Value();
    std::transform(name.begin(), name.end(), name.begin(), ::toupper);
+	EDigitizer tmpType = EDigitizer::kDefault;
    if(name.compare("GRF16") == 0) {
-      return EDigitizer::kGRF16;
-   }
-   if(name.compare("GRF4G") == 0) {
-      return EDigitizer::kGRF4G;
-   }
-   if(name.compare("TIG10") == 0) {
-      return EDigitizer::kTIG10;
-   }
-   if(name.compare("TIG64") == 0) {
-      return EDigitizer::kTIG64;
-   }
-   if(name.compare("CAEN") == 0) {
-      return EDigitizer::kCaen;
-   }
-	std::cout<<"Warning, digitizer type '"<<name<<"' not recognized, options are 'GRF16', 'GRF4G', 'TIG10', 'TIG64', and 'CAEN'!"<<std::endl;
-   return EDigitizer::kDefault;
+		tmpType = EDigitizer::kGRF16;
+   } else if(name.compare("GRF4G") == 0) {
+		tmpType = EDigitizer::kGRF4G;
+   } else if(name.compare("TIG10") == 0) {
+		tmpType = EDigitizer::kTIG10;
+   } else if(name.compare("TIG64") == 0) {
+		tmpType = EDigitizer::kTIG64;
+   } else if(name.compare("CAEN") == 0) {
+		tmpType = EDigitizer::kCaen;
+   } else {
+		std::cout<<"Warning, digitizer type '"<<name<<"' not recognized, options are 'GRF16', 'GRF4G', 'TIG10', 'TIG64', and 'CAEN'!"<<std::endl;
+	}
+	digitizerType.Set(tmpType, digitizerName.Priority());
 }
 
 void TGRSIMnemonic::Parse(std::string* name)

--- a/libraries/TGRSIFormat/TGRSIMnemonic.cxx
+++ b/libraries/TGRSIFormat/TGRSIMnemonic.cxx
@@ -104,6 +104,7 @@ TGRSIMnemonic::EDigitizer TGRSIMnemonic::EnumerateDigitizer(std::string name)
    if(name.compare("CAEN") == 0) {
       return EDigitizer::kCaen;
    }
+	std::cout<<"Warning, digitizer type '"<<name<<"' not recognized, options are 'GRF16', 'GRF4G', 'TIG10', 'TIG64', and 'CAEN'!"<<std::endl;
    return EDigitizer::kDefault;
 }
 

--- a/src/GRSIDataLibrary.cxx
+++ b/src/GRSIDataLibrary.cxx
@@ -3,6 +3,8 @@
 #include "TMidasFile.h"
 #include "TGRSIDataParser.h"
 #include "GRSIDataVersion.h"
+#include "TChannel.h"
+#include "TGRSIMnemonic.h"
 
 extern "C" TMidasFile* CreateFile(std::string& fileName) { return new TMidasFile(fileName.c_str()); }
 extern "C" void DestroyFile(TMidasFile* obj) { delete obj; }
@@ -11,3 +13,5 @@ extern "C" TGRSIDataParser* CreateParser() { return new TGRSIDataParser; }
 extern "C" void DestroyParser(TGRSIDataParser* obj) { delete obj; }
 
 extern "C" std::string LibraryVersion() { return std::string(GRSIDATA_RELEASE); }
+
+extern "C" void InitLibrary() { TChannel::SetMnemonicClass(TGRSIMnemonic::Class()); }

--- a/util/GetTreeEntries.cxx
+++ b/util/GetTreeEntries.cxx
@@ -11,7 +11,6 @@
 #include "TGriffin.h"
 #include "TDescant.h"
 #include "TFragment.h"
-#include "TMnemonic.h"
 #include "TLaBr.h"
 #include "TZeroDegree.h"
 #include "TSceptar.h"


### PR DESCRIPTION
- Added LibraryInit function that sets the mnemonic class for the
  TChannel to the appropriate choice for the library.
- EnumerateDigitizer now produces warning message if string is not
  recognized.
- Instead of taking a string and returning the digitizer enum class
  EnumerateDigitizer now takes the name and type of the digitizer as
  TPriorityValue references as arguments (return value is void).
- Changed all references from TMnemonic to TGRSIMnemonic.
- EDigitizer is not part of the TMnemonic namespace anymore and is
  defined only within the data parser library.
- Removed random includes of TMnemonic.h.