### PR TITLE
Fixed some issues, changed default to sorting by time stamp

### DIFF
--- a/include/TGRSIDataParser.h
+++ b/include/TGRSIDataParser.h
@@ -78,11 +78,11 @@ public:
 #ifndef __CINT__
 	int Process(std::shared_ptr<TRawEvent>) override;
 	int ProcessGriffin(uint32_t* data, const int& size, const EBank& bank, std::shared_ptr<TMidasEvent>& event);
+   int TigressDataToFragment(uint32_t* data, int size, std::shared_ptr<TMidasEvent>& event);
 	int CaenToFragment(uint32_t* data, int size, std::shared_ptr<TMidasEvent>& event);
 #endif
 
 public:
-   int TigressDataToFragment(uint32_t* data, int size, unsigned int midasSerialNumber = 0, time_t midasTime = 0);
    int GriffinDataToFragment(uint32_t* data, int size, EBank bank, unsigned int midasSerialNumber = 0,
                              time_t midasTime = 0);
    int GriffinDataToPPGEvent(uint32_t* data, int size, unsigned int midasSerialNumber = 0, time_t midasTime = 0);

--- a/include/TGRSIDataParser.h
+++ b/include/TGRSIDataParser.h
@@ -78,6 +78,7 @@ public:
 #ifndef __CINT__
 	int Process(std::shared_ptr<TRawEvent>) override;
 	int ProcessGriffin(uint32_t* data, const int& size, const EBank& bank, std::shared_ptr<TMidasEvent>& event);
+	int CaenToFragment(uint32_t* data, int size, std::shared_ptr<TMidasEvent>& event);
 #endif
 
 public:
@@ -89,7 +90,6 @@ public:
 
    int EPIXToScalar(float* data, int size, unsigned int midasSerialNumber = 0, time_t midasTime = 0);
    int SCLRToScalar(uint32_t* data, int size, unsigned int midasSerialNumber = 0, time_t midasTime = 0);
-	int CaenToFragment(uint32_t* data, int size);
    int EightPIDataToFragment(uint32_t stream, uint32_t* data, int size, unsigned int midasSerialNumber = 0,
                              time_t midasTime = 0);
 

--- a/include/TGRSIDetectorInformation.h
+++ b/include/TGRSIDetectorInformation.h
@@ -78,27 +78,29 @@ private:
    //  detector types to switch over in Set()
    //  for more info, see: https://www.triumf.info/wiki/tigwiki/index.php/Detector_Nomenclature
 
-	bool fDescantAncillary{false};  // Descant is in the ancillary detector locations
+	bool fDescantAncillary{false};  ///< Descant is in the ancillary detector locations
 
-   bool fTigress{false}; // flag for Tigress on/off
-   bool fSharc{false};   // flag for Sharc on/off
-   bool fTriFoil{false}; // flag for TriFoil on/off
-   bool fRf{false};      // flag for RF on/off
-   bool fCSM{false};     // flag for CSM on/off
-   bool fSpice{false};   // flag for Spice on/off
-   bool fTip{false};     // flag for Tip on/off
-   bool fS3{false};      // flag for S3 on/off
-   bool fGeneric{false}; // flag for Generic on/off
-   bool fBambino{false}; // flag for Bambino on/off
+   bool fTigress{false}; ///< flag for Tigress on/off
+   bool fSharc{false};   ///< flag for Sharc on/off
+   bool fTriFoil{false}; ///< flag for TriFoil on/off
+   bool fRf{false};      ///< flag for RF on/off
+   bool fCSM{false};     ///< flag for CSM on/off
+   bool fSpice{false};   ///< flag for Spice on/off
+   bool fTip{false};     ///< flag for Tip on/off
+   bool fS3{false};      ///< flag for S3 on/off
+   bool fGeneric{false}; ///< flag for Generic on/off
+   bool fBambino{false}; ///< flag for Bambino on/off
 
-   bool fGriffin{false};    // flag for Griffin on/off
-   bool fSceptar{false};    // flag for Sceptar on/off
-   bool fPaces{false};      // flag for Paces on/off
-   bool fDante{false};      // flag for LaBr on/off
-   bool fZeroDegree{false}; // flag for Zero Degree Scintillator on/off
-   bool fDescant{false};    // flag for Descant on/off
+   bool fGriffin{false};    ///< flag for Griffin on/off
+   bool fSceptar{false};    ///< flag for Sceptar on/off
+   bool fPaces{false};      ///< flag for Paces on/off
+   bool fDante{false};      ///< flag for LaBr on/off
+   bool fZeroDegree{false}; ///< flag for Zero Degree Scintillator on/off
+   bool fDescant{false};    ///< flag for Descant on/off
 
-   bool fBgo{false};        // flag for Bgo on/off
+   bool fBgo{false};        ///< flag for Bgo on/off
+
+	bool fSortByTriggerId{false}; ///< flag to sort by trigger ID instead of time stamp
 
    /// \cond CLASSIMP
    ClassDefOverride(TGRSIDetectorInformation, 1); // Contains the run-dependent information.

--- a/libraries/TGRSIFormat/TGRSIDetectorInformation.cxx
+++ b/libraries/TGRSIFormat/TGRSIDetectorInformation.cxx
@@ -22,10 +22,10 @@ TGRSIDetectorInformation::~TGRSIDetectorInformation() = default;
 
 TEventBuildingLoop::EBuildMode TGRSIDetectorInformation::BuildMode() const
 {
-	if(Griffin()) {
-		return TEventBuildingLoop::EBuildMode::kTimestamp;
+	if(fSortByTriggerId) {
+		return TEventBuildingLoop::EBuildMode::kTriggerId;
 	}
-	return TEventBuildingLoop::EBuildMode::kTriggerId;
+	return TEventBuildingLoop::EBuildMode::kTimestamp;
 }
 
 void TGRSIDetectorInformation::Print(Option_t* opt) const
@@ -93,6 +93,11 @@ void TGRSIDetectorInformation::Set()
    for(iter = TChannel::GetChannelMap()->begin(); iter != TChannel::GetChannelMap()->end(); iter++) {
       std::string channelname = iter->second->GetName();
 
+		// check if we have an old TIG digitizer, in that case sort by trigger ID (instead of time stamp)
+		// don't need to check again if we already found one, so include check for fSortByTriggerId being true
+		if(!fSortByTriggerId && (iter->second->GetDigitizerType() == EDigitizer::kTIG10 || iter->second->GetDigitizerType() == EDigitizer::kTIG64)) {
+			fSortByTriggerId = true;
+		}
       //  detector system type.
       //  for more info, see: https://www.triumf.info/wiki/tigwiki/index.php/Detector_Nomenclature
       switch(static_cast<const TGRSIMnemonic*>(iter->second->GetMnemonic())->System()) {


### PR DESCRIPTION
- Fixed issues with good CAEN fragments not being counted and added boardID to address of CAEN fragments.
- Added incrementation of good fragment counter for TIGRESS and EPICS data as well.
- Switched default sorting to timestamp.
- We are now checking for tig10 or tig64 digitizers to change the sorting behavior to trigger ID. This means if old TIGRESS data is being sorted the digitizer types have to be set in the cal file, otherwise the data will be sorted by time stamp!