### PR TITLE
Fixed double free on ending program

### DIFF
--- a/include/TSiLi.h
+++ b/include/TSiLi.h
@@ -110,7 +110,6 @@ public:
 // 3 use slow TF1 with experimental oscillation
    static int FitSiLiShape;     //!<!
    static double BaseFreq;     //!<!
-   static std::string fPreAmpName[8];     //!<!
 	
 private:
    std::vector<TSiLiHit> fAddbackHits;     //!<!

--- a/libraries/TGRSIAnalysis/TSiLi/TSiLi.cxx
+++ b/libraries/TGRSIAnalysis/TSiLi/TSiLi.cxx
@@ -22,8 +22,6 @@ double TSiLi::BaseFreq=4;
 double  TSiLi::fSiLiCoincidenceTime = 200;
 bool  TSiLi::fRejectPossibleCrosstalk = false;
 
-std::string TSiLi::fPreAmpName[8]={"RG","RB","LG","LB","LW","LR","RW","RR"};
-
 int TSiLi::FitSiLiShape = 0; // 0 no. 1 try if normal fit fail. 2 yes
 
 TSiLi::TSiLi()

--- a/util/config
+++ b/util/config
@@ -41,7 +41,7 @@ fi
 libdir=$GRSISYS/GRSIData/lib
 incdir=$GRSISYS/GRSIData/include
 
-libs="-lTAngularCorrelation -lTCSM -lTDescant -lTGRSIAnalysis -lTGRSIDataParser -lTGRSIDetector -lTGRSIFormat -lTGenericDetector -lTGriffin -lTLaBr -lTMidas -lTPaces -lTRF -lTS3 -lTSceptar -lTSharc -lTSiLi -lTTAC -lTTigress -lTTip -lTTriFoil -lTZeroDegree"
+libs="-lTAngularCorrelation -lTCSM -lTDescant -lTGRSIDataParser -lTGRSIDetector -lTGRSIFormat -lTGenericDetector -lTGriffin -lTLaBr -lTMidas -lTPaces -lTRF -lTS3 -lTSceptar -lTSharc -lTSiLi -lTTAC -lTTigress -lTTip -lTTriFoil -lTZeroDegree -lTEmma"
 
 cflags="-std=c++0x -I$incdir"
 


### PR DESCRIPTION
- Fixed "double free or corruption" error that sometimes occurred when stopping grsisort, grsiproof, or other programs compiled with grsisort libraries.
- Updated config script to include TEmma library and removed non-existent TGRSIAnalysis library.