### PR TITLE
Replaced cout with TSortingDiagnostics::RemovedHits

### DIFF
--- a/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
@@ -8,6 +8,7 @@
 #include "TInterpreter.h"
 
 #include "TGRSIOptions.h"
+#include "TSortingDiagnostics.h"
 
 /// \cond CLASSIMP
 ClassImp(TTigress)
@@ -178,13 +179,12 @@ TTigressHit* TTigress::GetAddbackHit(const int& i)
 
 void TTigress::BuildHits()
 {
-	//remove all hits of segments only
+	// remove all hits of segments only
+	// remove_if moves all elements to be removed to the end and returns an iterator to the first one to be removed
 	auto remove = std::remove_if(fHits.begin(), fHits.end(), [](TDetectorHit* h) -> bool { return !(static_cast<TTigressHit*>(h)->CoreSet());});
-	if(remove != fHits.end()) {
-		std::cout<<"removing "<<std::distance(remove, fHits.end())<<" TIGRESS hits without cores out of "<<fHits.size()<<" hits"<<std::flush;
-		fHits.erase(remove, fHits.end());
-		std::cout<<" leaving "<<fHits.size()<<" hits!"<<std::endl;
-	}
+	// using remove_if the elements to be removed are left in an undefined state so we can only log how many we are removing!
+	TSortingDiagnostics::Get()->RemovedHits(IsA(), std::distance(remove, fHits.end()), fHits.size());
+	fHits.erase(remove, fHits.end());
 	for(auto hit : fHits) {
 		auto tigressHit = static_cast<TTigressHit*>(hit);
       if(tigressHit->GetNSegments() > 1) {

--- a/util/html_generator.C
+++ b/util/html_generator.C
@@ -120,34 +120,33 @@ void html_generator() {
    gSystem->ListLibraries();
 
    THtmlCreator html;
-   html.SetProductName("GRSISort");
+   html.SetProductName("GRSIData");
    html.AddRootSourcePath();
    html.SetEtcDir("etc/html");
 //We must do this because of our naming convention of GRSISort directories
-   html.AddSourcePath("GROOT");
    html.AddSourcePath("TGRSIFormat"); 
-   html.AddSourcePath("TDataParser");
-   html.AddSourcePath("TGint");
-   html.AddSourcePath("TGRSILoop");
-   html.AddSourcePath("TAnalysis");
+   html.AddSourcePath("TGRSIDataParser");
+   html.AddSourcePath("TGRSIAnalysis");
    html.AddSourcePath("TMidas");
-   html.AddSourcePath("TGRSIint");
-   html.AddSourcePath("TGRSIRootIO");
-   html.AddSourcePath("TAnalysis/TAnalysisTreeBuilder");
-   html.AddSourcePath("TAnalysis/TKinematics");
-   html.AddSourcePath("TAnalysis/TNucleus");
-   html.AddSourcePath("TAnalysis/TSharc");
-   html.AddSourcePath("TAnalysis/TCSM");
-   html.AddSourcePath("TAnalysis/TGriffin");
-   html.AddSourcePath("TAnalysis/TGRSIFit");
-   html.AddSourcePath("TAnalysis/TPaces");
-   html.AddSourcePath("TAnalysis/TSceptar");
-   html.AddSourcePath("TAnalysis/TSharc");
-   html.AddSourcePath("TAnalysis/TSRIM");
-   html.AddSourcePath("TAnalysis/TGRSIDetector");
-   html.AddSourcePath("TAnalysis/TTigress");
-   html.AddSourcePath("TAnalysis/TBetaDecay");
-   html.AddSourcePath("TAnalysis/TCal");
+   html.AddSourcePath("TGRSIAnalysis/TAngularCorrelation");
+   html.AddSourcePath("TGRSIAnalysis/TCSM");
+   html.AddSourcePath("TGRSIAnalysis/TDescant");
+   html.AddSourcePath("TGRSIAnalysis/TEmma");
+   html.AddSourcePath("TGRSIAnalysis/TGenericDetector");
+   html.AddSourcePath("TGRSIAnalysis/TGriffin");
+   html.AddSourcePath("TGRSIAnalysis/TGRSIDetector");
+   html.AddSourcePath("TGRSIAnalysis/TLaBr");
+   html.AddSourcePath("TGRSIAnalysis/TPaces");
+   html.AddSourcePath("TGRSIAnalysis/TRF");
+   html.AddSourcePath("TGRSIAnalysis/TS3");
+   html.AddSourcePath("TGRSIAnalysis/TSceptar");
+   html.AddSourcePath("TGRSIAnalysis/TSharc");
+   html.AddSourcePath("TGRSIAnalysis/TSiLi");
+   html.AddSourcePath("TGRSIAnalysis/TTAC");
+   html.AddSourcePath("TGRSIAnalysis/TTigress");
+   html.AddSourcePath("TGRSIAnalysis/TTip");
+   html.AddSourcePath("TGRSIAnalysis/TTriFoil");
+   html.AddSourcePath("TGRSIAnalysis/TZeroDegree");
 
    html.RunAll();
 }


### PR DESCRIPTION
Using new function TSortingDiagnostics::RemovedHits to track how many tigress hits have been removed due to missing cores (see issue GRIFFINCollaboration/GRSISort#1094).