### PR TITLE
Support for new GRIF-16 RF data format

### DIFF
--- a/include/TGRSIDataParser.h
+++ b/include/TGRSIDataParser.h
@@ -91,6 +91,8 @@ public:
    int GriffinDataToPPGEvent(uint32_t* data, int size, unsigned int midasSerialNumber = 0, time_t midasTime = 0);
    int GriffinDataToScalerEvent(uint32_t* data, int address);
 
+   int RFScalerToFragment(uint32_t* data, const int size, const std::shared_ptr<TFragment>& frag);
+
    int EPIXToScalar(float* data, int size, unsigned int midasSerialNumber = 0, time_t midasTime = 0);
    int SCLRToScalar(uint32_t* data, int size, unsigned int midasSerialNumber = 0, time_t midasTime = 0);
    int EightPIDataToFragment(uint32_t stream, uint32_t* data, int size, unsigned int midasSerialNumber = 0,

--- a/include/TGRSIDataParser.h
+++ b/include/TGRSIDataParser.h
@@ -72,6 +72,7 @@ public:
       kBadBank,
       kBadModuleType,
       kEndOfData,
+      kBadRFScalerWord,
       kUndefined
    };
 

--- a/include/TRF.h
+++ b/include/TRF.h
@@ -61,7 +61,7 @@ public:
 private:
    time_t fMidasTime;
    Long_t fTimeStamp;
-   double fTime;
+   double fTime; //RF time offset from timestamp, like a CFD value
 
    static Double_t fPeriod;
 

--- a/include/TRF.h
+++ b/include/TRF.h
@@ -21,8 +21,16 @@ public:
    TRF(const TRF&);
    ~TRF() override;
 
-   Double_t Phase() const { return (fTime / fPeriod) * TMath::TwoPi(); }
-   Double_t Time() const { return fTime; }//in ns, not tstamp 10ns
+   Double_t Phase() const 
+   {
+      if(fPeriod > 0.0f) {
+         return (fTime / fPeriod) * TMath::TwoPi(); 
+      } else {
+         return -10.0; //negative value indicates failed RF fit
+      }
+   }
+   Double_t Time() const { return fTime; } //in ns, not tstamp 10ns
+   Double_t Period() const { return fPeriod; } //in ns
    Long_t   TimeStamp() const { return fTimeStamp; }
    time_t   MidasTime() const { return fMidasTime; }
 
@@ -62,8 +70,7 @@ private:
    time_t fMidasTime;
    Long_t fTimeStamp;
    double fTime; //RF time offset from timestamp, like a CFD value
-
-   static Double_t fPeriod;
+   double fPeriod;
 
    /// \cond CLASSIMP
    ClassDefOverride(TRF, 4)

--- a/libraries/TGRSIAnalysis/TRF/TRF.cxx
+++ b/libraries/TGRSIAnalysis/TRF/TRF.cxx
@@ -4,8 +4,6 @@
 ClassImp(TRF)
 /// \endcond
 
-Double_t TRF::fPeriod;
-
 TRF::TRF()
 {
    Clear();
@@ -17,6 +15,7 @@ void TRF::Copy(TObject& rhs) const
    static_cast<TRF&>(rhs).fMidasTime = fMidasTime;
    static_cast<TRF&>(rhs).fTimeStamp = fTimeStamp;
    static_cast<TRF&>(rhs).fTime      = fTime;
+   static_cast<TRF&>(rhs).fPeriod    = fPeriod;
 }
 
 TRF::TRF(const TRF& rhs) : TDetector()
@@ -39,8 +38,8 @@ void TRF::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel*)
       //special RF scaler format
       //no waveform, only fit parameters
 
-      //the phase shift (in cfd units) is stored as the cfd
-      //the period (in ns) is stored as the charge
+      //the phase shift (in cfd units) is stored in the fragment as the cfd
+      //the period (in ns) is stored in the fragment as the charge
 
       fTime = frag->GetCfd() / 1.6; //convert from cfd units to ns
       fPeriod = frag->GetCharge();

--- a/libraries/TGRSIAnalysis/TRF/TRF.cxx
+++ b/libraries/TGRSIAnalysis/TRF/TRF.cxx
@@ -28,11 +28,23 @@ TRF::~TRF() = default;
 
 void TRF::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel*)
 {
+
+   fMidasTime = frag->GetDaqTimeStamp();
+   fTimeStamp = frag->GetTimeStamp();
+
    TPulseAnalyzer pulse(*frag);
    if(pulse.IsSet()) {
       fTime      = pulse.fit_rf(fPeriod * 0.2); // period taken in half ticks... for reasons
-      fMidasTime = frag->GetDaqTimeStamp();
-      fTimeStamp = frag->GetTimeStamp();
+   }else{
+      //special RF scaler format
+      //no waveform, only fit parameters
+
+      //the phase shift (in cfd units) is stored as the cfd
+      //the period (in ns) is stored as the charge
+
+      fTime = frag->GetCfd() / 1.6; //convert from cfd units to ns
+      fPeriod = frag->GetCharge();
+
    }
 }
 
@@ -42,7 +54,7 @@ void TRF::Clear(Option_t*)
    fTimeStamp = 0.0;
    fTime      = 0.0;
 
-   fPeriod = 84.409;
+   fPeriod = 84.8417;
 }
 
 void TRF::Print(Option_t*) const

--- a/libraries/TGRSIDataParser/TGRSIDataParser.cxx
+++ b/libraries/TGRSIDataParser/TGRSIDataParser.cxx
@@ -1276,7 +1276,7 @@ int TGRSIDataParser::RFScalerToFragment(uint32_t* data, const int size, const st
 					tsSet=true;
 				}else{
 					TParsingDiagnostics::Get()->BadFragment(frag->GetDetectorType());
-					fState     = EDataParserState::kBadHighTS;
+					fState     = EDataParserState::kBadRFScalerWord;
 					failedWord = x;
 					Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*frag, data, size, failedWord, false));
 					//std::cout << "Invalid RF high time stamp!" << std::endl;
@@ -1313,7 +1313,7 @@ int TGRSIDataParser::RFScalerToFragment(uint32_t* data, const int size, const st
 	if(!(x<size-3)){
 		//std::cout << "RF fragment does not contain all parameters." << std::endl;
 		TParsingDiagnostics::Get()->BadFragment(frag->GetDetectorType());
-		fState     = EDataParserState::kWrongNofWords;
+		fState     = EDataParserState::kBadRFScalerWord;
 		failedWord = x;
 		Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*frag, data, size, failedWord, false));
 		return -1;
@@ -1321,7 +1321,7 @@ int TGRSIDataParser::RFScalerToFragment(uint32_t* data, const int size, const st
 	if((data[x]==data[x+1])&&(data[x]==data[x+2])&&(data[x]==data[x+3])){
 		//std::cout << "Failed RF fit: all parameters are the same value." << std::endl;
 		TParsingDiagnostics::Get()->BadFragment(frag->GetDetectorType());
-		fState     = EDataParserState::kUndefined;
+		fState     = EDataParserState::kBadRFScalerWord;
 		failedWord = x;
 		Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*frag, data, size, failedWord, false));
 		return -1;
@@ -1345,7 +1345,7 @@ int TGRSIDataParser::RFScalerToFragment(uint32_t* data, const int size, const st
 			if((i!=2)&&(dword == 0)){
 				//std::cout << "Failed RF fit: non-offset parameter is zero." << std::endl;
 				TParsingDiagnostics::Get()->BadFragment(frag->GetDetectorType());
-				fState     = EDataParserState::kUndefined;
+				fState     = EDataParserState::kBadRFScalerWord;
 				failedWord = x;
 				Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*frag, data, size, failedWord, false));
 				return -1;
@@ -1364,10 +1364,8 @@ int TGRSIDataParser::RFScalerToFragment(uint32_t* data, const int size, const st
 					dword ^= 1 << j;
 				}
 				rfPar[i] = static_cast<double>(-1.0*(dword & 0x03ffffff)); //RF fit parameters (30-bit numbers)
-				//printf("par %i: %f\n",i,-1.0*(dword & 0x03ffffff));
 			}else{
 				rfPar[i] = static_cast<double>(dword & 0x03ffffff); //RF fit parameters (30-bit numbers)
-				//printf("par %i: %f\n",i,1.0*(dword & 0x03ffffff));
 			}
 			
 			x++;
@@ -1395,7 +1393,6 @@ int TGRSIDataParser::RFScalerToFragment(uint32_t* data, const int size, const st
 
 	frag->SetCharge(static_cast<float>(T)); //period stored as charge (where else would I put it?)
 	frag->SetCfd(static_cast<float>(rfPhaseShift) * 1.6f); //phase shift in cfd units (this one seems reasonable)
-	//std::cout << "RF period: " << T << " ns, phase shift: " << rfPhaseShift << " ns." << std::endl;
 
 	Push(fGoodOutputQueues, std::make_shared<TFragment>(*frag));
 	return 1;


### PR DESCRIPTION
This is a cleanup/rewrite of some code I've been running over the past few TIGRESS experiments, to handle a new RF data format we've adopted.  Basically, recent GRIF-16 firmwares have a special RF mode (https://grsi.wiki.triumf.ca/index.php/GRIF-16#RF_Mode) which fits the RF waveform online and only writes the fit parameters to disk in a scaler format (also described in the linked page).  This saves the need to write waveforms, which take up a significant amount of disk space.  Using the fit parameters and timestamps of individual RF scaler 'events', the RF phase at any given time during a run can be reconstructed and events can be timed with respect to the RF phase.

This PR tries to make this new RF scaler event format compatible with the existing TRF class (and hopefully not breaking the old-style RF data, if anyone is still analyzing that).  I added a new parsing function (TGRSIDataParser::RFScalerToFragment) to convert the RF scaler data to an RF fragment.  I did this because even though the RF data is technically a scaler, I think its data should go to the fragment queue rather than the scaler queue, so that RF events can be built in the analysis tree (just like the old style RF waveform data).  I've also slightly modified the TRF class to handle the RF fragments I construct.  There are a few implementation details where I'm not sure I have the best solution (let me know if I should change anything):

* The logic converting the RF fit parameters to the values of interest (RF period and phase shift) is in TGRSIDataParser::RFScalerToFragment.  It might be better to put this logic in the TRF class, but then the RF fragment would have to store the 5 (32-bit) fit parameters for each event, and there doesn't seem to be anywhere in TFragment for these parameters to be stored.
* After doing the aforementioned conversion, I store the RF period and phase shift as the Charge and Cfd values in the RF fragment.  There didn't seem to be any good place to store floating point parameter values in TFragment, so I chose Charge and Cfd since:
   * They were otherwise unused (charge doesn't have any meaning for RF events).
   * The phase shift represents a timing offset from the timestamp and is conceptually similar to the Cfd value.

Of course, I could modify TFragment to add storage space for the RF fit parameters, but it would mean having a bunch of extra variables which are left empty except in the very specific case of analyzing RF scaler data.