### PR TITLE
Updates to TRIFIC Class

### DIFF
--- a/include/TTrific.h
+++ b/include/TTrific.h
@@ -35,40 +35,52 @@ class TTrific : public TDetector {
 		TTrificHit* GetTrificHit(const int& i) const { return static_cast<TTrificHit*>(GetHit(i)); }
 
 #ifndef __CINT__
-		void AddFragment(const std::shared_ptr<const TFragment>&, TChannel*) override;
+		void AddFragment(const std::shared_ptr<const TFragment>&, TChannel* chan) override;
 #endif
 		void BuildHits() override {} // no need to build any hits, everything already done in AddFragment
 
-		Int_t GetXYGrid(char grid, const TTrific& event); //!<!
 
-		static TVector3 GetPosition(Int_t DetectorNumber); //!<!
+		//TVector3 GetPosition(const TTrificHit& hit,Int_t detectorNumber); //!<!
+		TVector3 GetPosition(Int_t detectorNumber); //!<!
 
 		TVector3 GetPosition(); //!<!
 
 
 		Int_t GetRange(); //!<!
+		
+		void GetXYGrid(); //!<!
 
 
 		TTrific& operator=(const TTrific&); //!<!
 
 	private:
 		static bool fSetCoreWave; //!<!  Flag for Waveforms ON/OFF
-
-		//static double xmm; //!<!
-		//static double xW; //!<!
-		//static double ymm; //!<!
-		//static double yW; //!<!
-		//static double spacing; //!<!
-		//static double initialSpacing; //!<!
-		//static Int_t gridX; //!<!
-		//static Int_t gridY; //!<!
-
+		
+		std::vector<TDetectorHit*> fXFragments; 
+		std::vector<TDetectorHit*> fYFragments; 
+		std::vector<TDetectorHit*> fSingFragments; 
 
 	public:
 		static bool SetCoreWave() { return fSetCoreWave; } //!<!
 
 		void Copy(TObject&) const override;            //!<!
 		void Print(Option_t* opt = "") const override; //!<!
+		void Clear(Option_t* = "") override; //!<!
+
+	private:
+		//physical information on the grids
+
+		static const double xmm[12]; //!
+		//static double xW[12]; //!
+		static const double ymm[12]; //!
+		//static double yW[12]; //!
+		static const double spacingCart; //!
+		static const double initialSpacingCart; //!
+		//for use in determining the XY grids
+		static Int_t gridX; //!
+		static Int_t gridY; //!
+		static const double angle; //!
+		static const TVector3 normalGridVec; //!
 
 		/// \cond CLASSIMP
 		ClassDefOverride(TTrific, 4) // TRIFIC Physics structure

--- a/include/TTrificHit.h
+++ b/include/TTrificHit.h
@@ -41,7 +41,8 @@ public:
    void Print(Option_t* opt = "") const override;      //!<!
    void     Copy(TObject&) const override;             //!<!
    //TVector3 GetPosition(Double_t dist) const override; //!<!
-   TVector3 GetPosition() const override;              //!<!
+   TVector3 GetPosition() const override;  //!<!             
+   //TVector3 GetPosition() const; //!<!
 
 private:
    Double_t GetDefaultDistance() const { return 0.0; }

--- a/libraries/TGRSIAnalysis/TTrific/TTrific.cxx
+++ b/libraries/TGRSIAnalysis/TTrific/TTrific.cxx
@@ -7,6 +7,34 @@
 ClassImp(TTrific)
 /// \endcond
 
+//declaration of static variables that won't change from event to event
+Int_t TTrific::gridX = 0;
+Int_t TTrific::gridY = 0;
+
+//declaration of constant variables
+
+//grid parameters for TRIFIC
+//double TTrific::xmm[12]={-42,-27,-21,-15,-9,-3,3,9,15,21,27,42};
+const double TTrific::xmm[12]={-33,-27,-21,-15,-9,-3,3,9,15,21,27,33}; //mm distance to the middle of each wire set readout from centre of grid
+//double TTrific::xW[12]={12,3,3,3,3,3,3,3,3,3,3,12}; //number of wires in eachreadout set
+
+//double TTrific::ymm[12]={48,36,28,20,12,4,-4,-12,-20,-28,-36,-48};
+const double TTrific::ymm[12]={42,36,28,20,12,4,-4,-12,-20,-28,-36,-42};
+//double TTrific::yW[12]={8,4,4,4,4,4,4,4,4,4,4,8};//number of wires, 2 mm spacing
+
+//angle that grids are offset by (in rads)
+const double TTrific::angle = (60./180.)*TMath::Pi();
+const TVector3 TTrific::normalGridVec = TVector3(0,-TMath::Cos(angle),TMath::Sin(angle)); //vector that points normal to the grid
+
+//normal to the faces
+//double spacing = 10.0; //mm between each grid
+//double initialSpacing = 20.0; //mm from the window to the first grid
+
+//in cartesian coordinates
+const double TTrific::spacingCart = 13.0; //mm
+const double TTrific::initialSpacingCart = 28.0; //mm
+
+
 bool TTrific::fSetCoreWave = false;
 
 TTrific::TTrific() : TDetector()
@@ -30,6 +58,11 @@ void TTrific::Copy(TObject& rhs) const
 	TDetector::Copy(rhs);
 
 	static_cast<TTrific&>(rhs).fSetCoreWave = fSetCoreWave;
+	
+	static_cast<TTrific&>(rhs).fXFragments = fXFragments;
+	static_cast<TTrific&>(rhs).fYFragments = fYFragments;
+	static_cast<TTrific&>(rhs).fSingFragments = fSingFragments;
+	
 }
 
 TTrific::~TTrific()
@@ -41,6 +74,9 @@ void TTrific::Print(Option_t*) const
 {
 	// Prints out TTrific members, currently does nothing.
 	printf("%lu fHits\n", fHits.size());
+	printf("%lu xHits\n",fXFragments.size());
+	printf("%lu yHits\n",fYFragments.size());
+	printf("%lu singHits\n",fSingFragments.size());
 }
 
 TTrific& TTrific::operator=(const TTrific& rhs)
@@ -49,146 +85,143 @@ TTrific& TTrific::operator=(const TTrific& rhs)
 	return *this;
 }
 
-void TTrific::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel*)
+void TTrific::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel* chan)
 {
 	TTrificHit* hit = new TTrificHit(*frag);
+	
+	//separate the fragments depending on if they are x, y, or single readout grids.
+	//this is based on the ArraySubPosition value of the hit. 
+	switch(chan->GetMnemonic()->ArraySubPosition()){
+		case TMnemonic::EMnemonic::kX:
+			//std::cout << "\nIdentified an X subposition";
+			fXFragments.push_back(hit);
+			break;
+		case TMnemonic::EMnemonic::kY:
+			fYFragments.push_back(hit);
+			//std::cout << "\nIdentified a Y subposition";
+			break;
+		default:
+			fSingFragments.push_back(hit);
+			break;
+	};
+	
+	//fHits.push_back(hit);
 	fHits.push_back(std::move(hit));
+	
+	return;
 }
 
-Int_t TTrific::GetXYGrid(char grid, const TTrific& event)
+void TTrific::Clear(Option_t* option)
 {
-	//used to determine which grid number are x or y grids
-	//this is used so that if we change the location of the x and y grids in TRIFIC,
-	//the only thing that will need to be modified is the ODB
+	TDetector::Clear(option);
+	fHits.clear();
+	
+	fXFragments.clear(); //!
+	fYFragments.clear(); //!
+	fSingFragments.clear(); //!
+	
+	return;
+}
 
-	Int_t gridNumber = 0; //GetDetector indexes at 1, so if we return a grid number of 0, we weren't able to find the position grid in this event
-	if('y' == grid || 'Y' == grid) {
-		//for(auto i = 0; i < GetMultiplicity(); i++) {
-		for(auto i = 0; i < event.GetMultiplicity(); i++) {
-			//y grids are [16,27], so need greater than 15 and less than 28
-			//if(static_cast<TTrificHit*>(GetHit(i))->GetSegment() > 15 && static_cast<TTrificHit*>(GetHit(i))->GetSegment() < 28) {
-			if(GetTrificHit(i)->GetSegment() > 15 && GetTrificHit(i)->GetSegment() < 28) {
-				gridNumber = GetTrificHit(i)->GetDetector();
-				break;
-			}
-		}
-	} else if('x' == grid || 'X' == grid) {
-		for(auto i = 0; i < event.GetMultiplicity(); i++) {
-			//for(auto i = 0; i < GetMultiplicity(); i++) {
-			//x grids are [1,12], so need greater than 0 and less than 13
-			if(GetTrificHit(i)->GetSegment() > 0 && GetTrificHit(i)->GetSegment() < 13) {
-				gridNumber = GetTrificHit(i)->GetDetector();
-				break;
-			}
+void TTrific::GetXYGrid()
+{
+	//check if we have already found the X grid location yet. If so, we don't need to do it again.
+	if (!gridX){ //if gridX == 0, then this will trigger indicating that we haven't found the X grid number yet	
+		if (fXFragments.size()){ //we have to have an x-grid hit in this event to determine the x-grid number
+			 TDetectorHit *hit = fXFragments.at(0);
+			 TTrificHit *trifXHit = static_cast<TTrificHit*>(hit);
+			 gridX = trifXHit->GetDetector();
 		}
 	}
+	//check if we have already found the Y grid location yet. If so, we don't need to do it again.
+	if (!gridY){ //if gridY == 0, then this will trigger indicating that we haven't found the Y grid number yet
+		if (fYFragments.size()){//we have to have an y-grid hit in this event to determine the y-grid number
+			 TDetectorHit *hit = fYFragments.at(0);
+			 TTrificHit *trifYHit = static_cast<TTrificHit*>(hit);
+			 gridY = trifYHit->GetDetector();
+		}	
+	}
 
-	return gridNumber;
+	return;
 }
 
-TVector3 TTrific::GetPosition(Int_t DetectorNumber)
+TVector3 TTrific::GetPosition(Int_t detectorNumber)
 {
-	// **** Under Development Still ****
-
 	//this is called on a TRIFIC hit, and will use the GetPosition() function below calculate
 	//the x,y,z position of the hit at that grid number
+	//gives outputs in (x,y,z) in cartesian (beam) coordinates
 
-	//GetRange();
+	//detectorNumber is indexed at 1. 
 
-	//return position;
-	return TVector3(0,0,DetectorNumber);
+	//TRIFIC only holds 24 detectors, so doesn't make sense to get the position for detectors 25+. Also doesn't make sense to get the position for grid numbers <1.
+	if (24 < detectorNumber || 1 > detectorNumber) return TVector3(-1,-1,detectorNumber);
+
+	double zCart = initialSpacingCart + spacingCart*detectorNumber; //cartesian distance to the grid of choice in the z-direction
+	//this ignores the extra (or lack of) Z due to the tilt of the grids
+
+	TVector3 vec = TTrific::GetPosition();
+
+	zCart += zCart*vec.Y()/(TMath::Sqrt(3)-vec.Y()); //this adds (or subtracts) the extra Z distance due to the offset in Y (which are tilted at 30 degs. from vertical)
+	//notes on geometry: 30-60-90 triangle, so Y=sqrt(3)*Z', and Y/(Z+Z') = tan(theta)
+	
+	TVector3 particle(zCart*vec.X(),zCart*vec.Y(),zCart);
+	
+	//return TVector3(0,0,detectorNumber);
+	return particle;
 }
 
 TVector3 TTrific::GetPosition()
 {
 	//Will calculate the x,y,z vector for the TRIFIC event and then return a 3-D vector
-	//that somehow represents the TRIFIC event
-
-	//angle that grids are offset by (in rads)
-	double angle = (60./180.)*TMath::Pi();
-	TVector3 normalGridVec = TVector3(0,-TMath::Cos(angle),TMath::Sin(angle)); //vector that points normal to the grid
-
-	//normal to the faces
-	//double spacing = 10.0; //mm between each grid
-	//double initialSpacing = 20.0; //mm from the window to the first grid
-
-	//in cartesian coordinates
-	double spacingCart = 13.0; //mm
-	double initialSpacingCart = 28.0; //mm
-
-	//grid parameters
-	//double xmm[12]={-42,-27,-21,-15,-9,-3,3,9,15,21,27,42};
-	double xmm[12]={-33,-27,-21,-15,-9,-3,3,9,15,21,27,33}; //mm distance to the middle of each wire set readout from centre of grid
-	//double xW[12]={12,3,3,3,3,3,3,3,3,3,3,12}; //number of wires in eachreadout set
-
-	//double ymm[12]={48,36,28,20,12,4,-4,-12,-20,-28,-36,-48};
-	double ymm[12]={42,36,28,20,12,4,-4,-12,-20,-28,-36,-42};
-	//double yW[12]={8,4,4,4,4,4,4,4,4,4,4,8};//number of wires, 2 mm spacing
+	//that represents the TRIFIC event
 
 	//Get the grids that are the X and Y grids in this setup
-	Int_t gridX = GetXYGrid('x',*this); //GetXYGrid() returns 0 if it is unable to find the grid in the event
-	Int_t gridY = GetXYGrid('y',*this);
+	GetXYGrid();
 
-	//std::cout << "\nX and Y grids are " << gridX << " " << gridY << "\n"; fflush(stdout);
-
-	if(!gridY || !gridX) {
-		//if we don't have both an x and y grid hit in this event, position reconstruction won't be possible.
-		//std::cout << "\nUnable to find both X and Y grids for this event.\n";
-		return TVector3(-1,-1,-1);
-	}	
+	//if we don't have both an x and y grid hit in this event, position reconstruction won't be possible.
+	if(0 == fXFragments.size() || 0 == fYFragments.size()) return TVector3(-1,-1,-1);
 
 	std::vector<double> xGridEnergy; //for keeping track of the hit energies
 	std::vector<double> yGridEnergy;
 
-	Int_t xMulti = 0; //keep track of the multiplicity of the x and y grids
-	Int_t yMulti = 0; //if we only have multiplicity 1, we won't need to do a weighted average later
-
-	for(auto i = 0; i < GetMultiplicity(); i++) {
-		Int_t det = GetTrificHit(i)->GetDetector();
-
-		//immediately discard any hits that aren't on the x or y grid
-		if(det != gridX && det != gridY) continue;
-
-		UInt_t seg = GetTrificHit(i)->GetSegment();
-		Double_t eng = GetTrificHit(i)->GetEnergy();
-
-		//set a lower threshold on the energy of the hit
-		if(3 > eng) continue; //arbitrary threshold at the moment
-
-		//if we have a segment of 0, something went weird, so we discard this hit
-		if(0 == seg) continue;
-
-		//std::cout << "\nDetector and segment are " << det << " " << seg; fflush(stdout);
-
-		if(det == gridX) {
-			//this will eventually create a vector with as many entries as the highest segment number
-			//and fill every non-zero entry with the energy from that segment
-			while(xGridEnergy.size() < seg) xGridEnergy.push_back(0); 
-			xGridEnergy[seg-1]= eng; //minus 1 because vector indexes at 0 and x segments start at 1
-			xMulti++; //increase the multiplicity of the x-hit
-		} else if(det == gridY) {
-			//same thing, create the vector for the y-grids
-			//std::cout << "\nSeg is " << seg << " and seg mod is " << seg % 16 << " and size of the grid is " << yGridEnergy.size(); fflush(stdout);
-			while(yGridEnergy.size() < (seg%15)) yGridEnergy.push_back(0); //have to mod this by 15 so that if there is a hit seg 16,
-			//it will create an entry in the matrix (since 16%16=0)
-			yGridEnergy[seg % 16] = eng; // mod 16 because the y-grids index starting at 16 and vector at 0
-			yMulti++; //increase multiplicity of y-hit
-		}
+	for (auto i: fXFragments){
+		//TDetectorHit *hit = fXFragments.at(i);
+		TDetectorHit *hit = i;
+		TTrificHit *trifXHit = static_cast<TTrificHit*>(hit);
+		UInt_t seg = trifXHit->GetSegment();
+		
+		if (3 > trifXHit->GetEnergy()) continue; //arbitrary threshold to avoid weird E<0 events
+		
+		while(xGridEnergy.size() <= seg) xGridEnergy.push_back(0);
+		xGridEnergy[seg] = trifXHit->GetEnergy();
 	}
+	
+	for (auto i: fYFragments){
+	
+		//TDetectorHit *hit = fYFragments.at(i);
+		TDetectorHit *hit = i;
+		TTrificHit *trifYHit = static_cast<TTrificHit*>(hit);
+		UInt_t seg = trifYHit->GetSegment();
+		
+		if (3 > trifYHit->GetEnergy()) continue; //arbitrary threshold to avoid weird E<0 events
+		
+		while(yGridEnergy.size() <= seg) yGridEnergy.push_back(0);
+		yGridEnergy[seg] = trifYHit->GetEnergy();
+	}
+
 
 	Double_t xMean = 0.0; //keeping track of the weighted mean
 	Double_t xEnergyTotal = 0.0; //keeping track of the total energy
 
-	if(xMulti > 1) { //we only have to loop through the x-hits if we have more than 1. 
-		//it's possible that this will get caught if we had a single x-hit, but it was on segment 0 somehow. Have to think about this more
-
+	if(fXFragments.size() > 1) { //we only have to loop through the x-hits if we have more than 1. 
+	
 		bool bStarted = false; //this will be used to see if we have started counting the hit
 
 		//go through the two grids and do a weighted average of the non-zero points in them
 		for(unsigned int i = 0; i < xGridEnergy.size(); i++) {
 			xEnergyTotal += xGridEnergy[i]; //add the energy of the hit to the total.
 
-			if(!bStarted) {//if we haven't hit a non-zero point yet, check to see if the current one is non-zer
+			if(!bStarted) {//if we haven't hit a non-zero point yet, check to see if the current one is non-zero
 				if(xGridEnergy[i]) { //if it is, we've hit the first segment with an energy from the hit. 
 					xMean += xmm[i]*xGridEnergy[i]; //add the weighted mean
 					bStarted = true; //signal that we have started averaging
@@ -199,9 +232,7 @@ TVector3 TTrific::GetPosition()
 					xMean += xmm[i]*xGridEnergy[i]; //add the weighted mean		
 				} else {
 					//if we have a discontinuous hit, don't bother to try to reconstruct the position
-					//std::cout << "\nProblem here on entry " << i;	
-					return TVector3(-1,-1,-2);				
-					//break;
+					return TVector3(-1,-1,-2);	
 				}
 			}
 		}
@@ -215,8 +246,7 @@ TVector3 TTrific::GetPosition()
 	Double_t yMean = 0.0; //keeping track of the weighted mean
 	Double_t yEnergyTotal = 0.0; //keeping track of the total energy
 
-	if(yMulti > 1) { //we only have to loop through the x-hits if we have more than 1. 
-		//it's possible that this will get caught if we had a single x-hit, but it was on segment 0 somehow. Have to think about this more
+	if(fYFragments.size() > 1) { //we only have to loop through the y-hits if we have more than 1. 
 
 		bool bStarted = false; //this will be used to see if we have started counting the hit
 
@@ -224,7 +254,7 @@ TVector3 TTrific::GetPosition()
 		for(unsigned int i = 0; i < yGridEnergy.size(); i++) {
 			yEnergyTotal += yGridEnergy[i]; //add the energy of the hit to the total.
 
-			if(!bStarted) {//if we haven't hit a non-zero point yet, check to see if the current one is non-zer
+			if(!bStarted) {//if we haven't hit a non-zero point yet, check to see if the current one is non-zero
 				if(yGridEnergy[i]) { //if it is, we've hit the first segment with an energy from the hit. 
 					yMean += ymm[i]*yGridEnergy[i]; //add the weighted mean
 					bStarted = true; //signal that we have started averaging
@@ -235,9 +265,7 @@ TVector3 TTrific::GetPosition()
 					yMean += ymm[i]*yGridEnergy[i]; //add the weighted mean		
 				} else {
 					//if we have a discontinuous hit, don't bother to try to reconstruct the position
-					//std::cout << "\nProblem here on entry " << i;	
 					return TVector3(-1,-1,-2);				
-					//break;
 				}
 			}
 		}
@@ -248,28 +276,29 @@ TVector3 TTrific::GetPosition()
 		}
 	}
 
-	/*
-		std::cout << "\nTest print here\n";
-		for (int i = 0; i < xGrid.size(); i++) {
-		std::cout << "\nI is " << i << " and value is " << xGrid[i];
-		}*/
-
 	//convert them into cartesion coordinates 
 	double yCart = yMean*TMath::Sin(angle); //shifts from grid coordinates to XYZ coordinates
-	double zCart = initialSpacingCart + spacingCart*gridY+yMean*TMath::Cos(angle); //add the initial distance from the window to the grid, plus the number of gaps between the initial grid and the Y grid, plus the extra z-amount due to the hit location
+	double zYCart = initialSpacingCart + spacingCart*gridY+yMean*TMath::Cos(angle); //add the initial distance from the window to the grid, plus the number of gaps between the initial grid and the Y grid, plus the extra z-amount due to the hit location
+	double zXCart = initialSpacingCart + spacingCart*gridX; //adds the initial distance from window to grid, plus gaps until the x grid. No angle dependence since the grids aren't shifted in angle in x-direction
 
-	double tanX = xMean/initialSpacingCart + spacingCart*gridX; //determine tangent of the angle in the XY plane
-	double tanY = yCart/zCart; //tan of angle in YZ plane
+	double tanX = xMean/zXCart; //determine tangent of the angle in the XY plane
+	double tanY = yCart/zYCart; //tan of angle in YZ plane
 
-	TVector3 particle = TVector3(tanX,tanY,1); //unnormalized "unit" vector of the particle's trajectory
+	//the particle trajectory below is working under the assumption that the beam is centered and hitting the window at exactly (0,0,0). 
+	//while this may not be 100% true, the beam should be tuned enough that any deviations from that will be small
+
+	TVector3 particle = TVector3(tanX,tanY,1); //unnormalized "unit" vector of the particle's trajectory.
+	// "X" and "Y" coordinates are the tangent of the angles of the trajectory in the XY and YZ planes, respectively
+	//TVector3 particleCart = TVector3(xMean,yCart,1); //this makes the vector in cartesian as opposed to angles.
+	//particleCart.Print();
 
 	//double ratioZX = 1./normalGridVec.Dot(particle.Unit()); //the Z->R corretion factor
 
-	fflush(stdout);
+	//fflush(stdout);
+	
+	//particle.Print();
 
 	return particle;
-
-	//return TVector3(xMean, yMean, -5);
 }
 
 Int_t TTrific::GetRange()
@@ -278,10 +307,8 @@ Int_t TTrific::GetRange()
 	//can't just use the size of fHits because there is no guarantee that every
 	//grid gets an event, plus the XY position grids may have multiplicity>1
 	Int_t range = 0;
-	for(unsigned i = 0; i < fHits.size(); i++) {
-		//for (auto i = 0; i < GetMultiplicity(); i++) {
-		//if (static_cast<TTrificHit*>(GetHit(i))->GetDetector() > range) range = static_cast<TTrificHit*>(GetHit(i))->GetDetector();
-		if(GetTrificHit(i)->GetDetector() > range) range = GetTrificHit(i)->GetDetector();			
+	for(auto hit: fHits) {
+		if(hit->GetDetector() > range) range = hit->GetDetector();			
 	}
 
 	return range;

--- a/libraries/TGRSIAnalysis/TTrific/TTrificHit.cxx
+++ b/libraries/TGRSIAnalysis/TTrific/TTrificHit.cxx
@@ -45,11 +45,13 @@ void TTrificHit::Print(Option_t*) const
 }
 
 TVector3 TTrificHit::GetPosition() const
+//TVector3 TTrificHit::GetPosition()
 {
 	//calling GetPosition() on a TRIFIC hit should return the x,y,z location of the hit at that grid number
 
 	//TVector3 particle = TTrific::GetPosition()
 
-	return TTrific::GetPosition(GetDetector());
+	//return TTrific::GetPosition(GetDetector());
+	return TVector3(1,1,1);
 }
 


### PR DESCRIPTION
2nd iteration of the TRIFIC detector class. Most of the changes are the result of three overarching changes:

1. Changing many variables that don't change from event to event (like physical parameters of TRIFIC) into static variables.
2. Creating separate fragments in the AddFragment() function for the x readout grids, y readout grids, and single readout grids.
3. Making use of the ArraySubPosition mnemonic to determine the x and y grids instead of relying on segment numbers.

GetPosition() and GetXYGrid() have been heavily modified to run more efficiently after the changes above. They now only iterate over the x and y fragments when determining the grids and position vector. Static variables have been assigned for the x and y grid locations, since those won't change between events.

GetPosition(det) has been modified to give the Cartesian (x,y,z) of the particle at the given detector.

I have also removed a lot of debugging lines.