### PR TITLE
Fix TIGRESS addback segfault

### DIFF
--- a/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
@@ -90,20 +90,12 @@ TTigress::TTigress(const TTigress& rhs) : TDetector()
    rhs.Copy(*this);
 }
 
-TTigress::~TTigress()
-{
-	for(auto hit : fAddbackHits) {
-		delete hit;
-	}
-}
+TTigress::~TTigress() = default;
 
 void TTigress::Copy(TObject& rhs) const
 {
    TDetector::Copy(rhs);
-	static_cast<TTigress&>(rhs).fAddbackHits.resize(fAddbackHits.size());
-	for(size_t i = 0; i < fAddbackHits.size(); ++i) {
-		static_cast<TTigress&>(rhs).fAddbackHits[i] = new TTigressHit(*static_cast<TTigressHit*>(fAddbackHits[i]));
-	}
+	 static_cast<TTigress&>(rhs).fAddbackHits  = fAddbackHits;
    static_cast<TTigress&>(rhs).fAddbackFrags = fAddbackFrags;
    static_cast<TTigress&>(rhs).fBgos = fBgos;
    static_cast<TTigress&>(rhs).fTigressBits  = 0;
@@ -113,9 +105,6 @@ void TTigress::Clear(Option_t* opt)
 {
    // Clears the mother, and all of the hits
    TDetector::Clear(opt);
-	for(auto hit : fAddbackHits) {
-		delete hit;
-	}
    fAddbackHits.clear();
    fAddbackFrags.clear();
    fBgos.clear();
@@ -145,9 +134,6 @@ Int_t TTigress::GetAddbackMultiplicity()
    }
    // if the addback has been reset, clear the addback hits
    if(!fTigressBits.TestBit(ETigressBits::kAddbackSet)) {
-		for(auto hit : fAddbackHits) {
-			delete hit;
-		}
 		fAddbackHits.clear();
 	} else {
 		return fAddbackHits.size();
@@ -312,9 +298,6 @@ void TTigress::ResetAddback()
 	/// the old addback hits will be stored instead.
 	/// This should have changed now, we're using the stored tigress bits to reset the addback
 	fTigressBits.SetBit(ETigressBits::kAddbackSet, false);
-	for(auto hit : fAddbackHits) {
-		delete hit;
-	}
 	fAddbackHits.clear();
 	fAddbackFrags.clear();
 }


### PR DESCRIPTION
With 'recent' (ie. last 2 years) versions of GRSIData, there is a segfault when calling GetAddbackMultiplicity() on a TTigressHit (at least when calling it from an external sortcode eg. https://github.com/e-j-w/GreasySortCodes/blob/master/S1801/SortCode/SortCode.cxx).  The reason I hadn't noticed this yet is that we were using older versions of GRSISort/GRSIData circa April 2019 for EMMA compatibility (I'm just now migrating to the latest versions).

The problem seems to originate in commit b4456bc1197cfd7316f896ff3b17338dd324e389 - specifically, the addition of

```
for(auto hit : fAddbackHits) {
	delete hit;
}
```

in various locations in TTigress.cxx.  That commit also has similar changes to the LaBr suppression - I'm not sure if there are any problems related to that since I haven't sorted LaBr data.  This PR just reverts the changes made to TTigress.cxx, but probably deserves some scrutiny since I'm not deeply familiar with the destructor logic (and most C++-isms in general, I mostly use C) and maybe there's a better way to do things.  At any rate, I can sort TIGRESS data without segfaulting after making these changes, and the sorted addback data looks reasonable.

On the bright side, I tried sorting some of the EMMA data from the recent S1801 experiment and it looks like the latest versions of GRSISort and GRSIData are handling it properly.