### PR TITLE
TRIFIC Updates: fragments, bits, and optimization

### DIFF
--- a/include/TTrific.h
+++ b/include/TTrific.h
@@ -24,41 +24,78 @@
 ///
 ////////////////////////////////////////////////////////////
 
+class TTrificHit;
+
 class TTrific : public TDetector {
 
 	public:
+
+		enum class ETrificBits {
+			kPositionCalculated = BIT(0),
+			kRangeCalculated = BIT(1),
+			kBit2 = BIT(2),
+			kBit3 = BIT(3),
+			kBit4 = BIT(4),
+			kBit5 = BIT(5),
+			kBit6 = BIT(6),
+			kBit7 = BIT(7),
+		};
+
 		TTrific();
 		TTrific(const TTrific&);
 		~TTrific() override;
 
+
 	public:
-		TTrificHit* GetTrificHit(const int& i) const { return static_cast<TTrificHit*>(GetHit(i)); }
+		//TTrificHit* GetTrificHit(const int& i) const { return static_cast<TTrificHit*>(GetHit(i)); } //current does nothing because we have moved all fragments into an X, Y, or Sing fragment
+		TTrificHit* GetTrificXHit(const int& i) const {return fXFragments.at(i);}
+		TTrificHit* GetTrificYHit(const int& i) const {return fYFragments.at(i);}
+		TTrificHit* GetTrificSingHit(const int& i) const {return fSingFragments.at(i);}
 
 #ifndef __CINT__
 		void AddFragment(const std::shared_ptr<const TFragment>&, TChannel* chan) override;
 #endif
 		void BuildHits() override {} // no need to build any hits, everything already done in AddFragment
 
+		void ClearTransients() override
+   		{
+      		fTrificBits = 0;
+			TDetector::ClearTransients();
+			particle.SetXYZ(0,0,0);
+			range = 0;
+   		}
+
+		//since we've eliminated fHits from TTrific, we need to redefine GetMultiplicity()
+		virtual Short_t GetMultiplicity() const override {return fXFragments.size()+fYFragments.size()+fSingFragments.size();} //Note: you cannot iterate over just the multiplicity, since there is no one vector will all hits in it
+		virtual Short_t GetXMultiplicity() const {return fXFragments.size();}
+		virtual Short_t GetYMultiplicity() const {return fYFragments.size();}
+		virtual Short_t GetSingMultiplicity() const {return fSingFragments.size();}
+
+		static TVector3 particle; //!<!
+
+		static Int_t range; //!<!
 
 		//TVector3 GetPosition(const TTrificHit& hit,Int_t detectorNumber); //!<!
 		TVector3 GetPosition(Int_t detectorNumber); //!<!
 
 		TVector3 GetPosition(); //!<!
 
-
 		Int_t GetRange(); //!<!
+
+		//TVector2 GetEdESimple(); //!<!
 		
 		void GetXYGrid(); //!<!
-
-
+		
 		TTrific& operator=(const TTrific&); //!<!
 
 	private:
 		static bool fSetCoreWave; //!<!  Flag for Waveforms ON/OFF
 		
-		std::vector<TDetectorHit*> fXFragments; 
-		std::vector<TDetectorHit*> fYFragments; 
-		std::vector<TDetectorHit*> fSingFragments; 
+		std::vector<TTrificHit*> fXFragments; 
+		std::vector<TTrificHit*> fYFragments; 
+		std::vector<TTrificHit*> fSingFragments; 
+
+		TTransientBits<UShort_t> fTrificBits;
 
 	public:
 		static bool SetCoreWave() { return fSetCoreWave; } //!<!
@@ -66,6 +103,10 @@ class TTrific : public TDetector {
 		void Copy(TObject&) const override;            //!<!
 		void Print(Option_t* opt = "") const override; //!<!
 		void Clear(Option_t* = "") override; //!<!
+		
+		static const double spacingCart; //!
+		static const double initialSpacingCart; //!
+		static double targetToWindowCart; //!
 
 	private:
 		//physical information on the grids
@@ -74,8 +115,7 @@ class TTrific : public TDetector {
 		//static double xW[12]; //!
 		static const double ymm[12]; //!
 		//static double yW[12]; //!
-		static const double spacingCart; //!
-		static const double initialSpacingCart; //!
+		
 		//for use in determining the XY grids
 		static Int_t gridX; //!
 		static Int_t gridY; //!

--- a/libraries/TGRSIAnalysis/TTrific/TTrificHit.cxx
+++ b/libraries/TGRSIAnalysis/TTrific/TTrificHit.cxx
@@ -47,11 +47,9 @@ void TTrificHit::Print(Option_t*) const
 TVector3 TTrificHit::GetPosition() const
 //TVector3 TTrificHit::GetPosition()
 {
-	//calling GetPosition() on a TRIFIC hit should return the x,y,z location of the hit at that grid number
+	//calling GetPosition() on a TRIFIC hit will return the position vector to the centre of the grid
+	//calling TTrific::GetPosition(det) will give the vector to the position itself.
 
-	//TVector3 particle = TTrific::GetPosition()
-
-	//return TTrific::GetPosition(GetDetector());
-	return TVector3(1,1,1);
+	return TVector3(0,0,TTrific::targetToWindowCart+TTrific::initialSpacingCart+TTrific::spacingCart*GetDetector());
 }
 


### PR DESCRIPTION
More updates to the TRIFIC class. The main things are:

1. Creating three different fragment vectors for x-grid, y-grid, and single-grid hits, as well as eliminating the fHits fragment from the class. Reasoning: for the most part, class functions will only need to access hits from the x, y, or single grids. So by separating these into different fragment vectors, we don't need to loop over a bunch of irrelevant hits when doing calculations.
2. Added in a TrificBits enum class to keep track of whether certain intensive calculations have been completed for the given TRIFIC event. For instance, TTrific::GetPosition() is quite intensive, but once it has been called on an event, the result won't change, so there's no reason to go back through the entire function if called again. 
3. General optimization of the code, with lots of it due to the changes made in points 1 and 2.

More updates to the class will come eventually, but since with a TIGRESS+TRIFIC scheduled to run next month, this should be enough for the class to be useful for it. It's likely that there will be no more class updates before then. 

I don't understand git well enough to know why it added the second commit "Merge branch 'GRIFFINCollaboration:master' into master" to this pull request, but hopefully that doesn't cause any problems.