### PR TITLE
Minor TRIFIC adjustments and variable name changes

### DIFF
--- a/include/TTrific.h
+++ b/include/TTrific.h
@@ -47,7 +47,7 @@ class TTrific : public TDetector {
 
 
 	public:
-		//TTrificHit* GetTrificHit(const int& i) const { return static_cast<TTrificHit*>(GetHit(i)); } //current does nothing because we have moved all fragments into an X, Y, or Sing fragment
+		TTrificHit* GetTrificHit(const int& i) const {return static_cast<TTrificHit*>(GetHit(i));}
 		TTrificHit* GetTrificXHit(const int& i) const {return fXFragments.at(i);}
 		TTrificHit* GetTrificYHit(const int& i) const {return fYFragments.at(i);}
 		TTrificHit* GetTrificSingHit(const int& i) const {return fSingFragments.at(i);}
@@ -61,19 +61,24 @@ class TTrific : public TDetector {
    		{
       		fTrificBits = 0;
 			TDetector::ClearTransients();
-			particle.SetXYZ(0,0,0);
-			range = 0;
+			fParticle.SetXYZ(0,0,0);
+			fRange = 0;
    		}
 
-		//since we've eliminated fHits from TTrific, we need to redefine GetMultiplicity()
-		virtual Short_t GetMultiplicity() const override {return fXFragments.size()+fYFragments.size()+fSingFragments.size();} //Note: you cannot iterate over just the multiplicity, since there is no one vector will all hits in it
+		virtual Short_t GetMultiplicity() const override {return fHits.size();}
 		virtual Short_t GetXMultiplicity() const {return fXFragments.size();}
 		virtual Short_t GetYMultiplicity() const {return fYFragments.size();}
 		virtual Short_t GetSingMultiplicity() const {return fSingFragments.size();}
 
-		static TVector3 particle; //!<!
+		//used to set the target to window distance depending on which experiment is running
+		static void SetSharc(Double_t distance = 650.57) {fTargetToWindowCart = distance;} //mm. 640.2mm from ideal target location to start of window housing, then 20.74mm window housing thickness
+		static void SetTip(Double_t distance = 600.) {fTargetToWindowCart = distance;} //mm. THIS IS ONLY A *ROUGH* APPROXIMATION
+		static void SetCustomTargetChamber(Double_t distance){fTargetToWindowCart = distance;}
 
-		static Int_t range; //!<!
+
+		TVector3 fParticle = TVector3(0,0,0); //!<!
+
+		Int_t fRange = 0; //!<!
 
 		//TVector3 GetPosition(const TTrificHit& hit,Int_t detectorNumber); //!<!
 		TVector3 GetPosition(Int_t detectorNumber); //!<!
@@ -104,23 +109,23 @@ class TTrific : public TDetector {
 		void Print(Option_t* opt = "") const override; //!<!
 		void Clear(Option_t* = "") override; //!<!
 		
-		static const double spacingCart; //!
-		static const double initialSpacingCart; //!
-		static double targetToWindowCart; //!
+		static const double fSpacingCart; //!
+		static const double fInitialSpacingCart; //!
+		static double fTargetToWindowCart; //!
 
 	private:
 		//physical information on the grids
 
-		static const double xmm[12]; //!
+		static const double fXmm[12]; //!
 		//static double xW[12]; //!
-		static const double ymm[12]; //!
+		static const double fYmm[12]; //!
 		//static double yW[12]; //!
 		
 		//for use in determining the XY grids
-		static Int_t gridX; //!
-		static Int_t gridY; //!
-		static const double angle; //!
-		static const TVector3 normalGridVec; //!
+		static Int_t fGridX; //!
+		static Int_t fGridY; //!
+		static const double fAngle; //!
+		static const TVector3 fNormalGridVec; //!
 
 		/// \cond CLASSIMP
 		ClassDefOverride(TTrific, 4) // TRIFIC Physics structure

--- a/libraries/TGRSIAnalysis/TTrific/TTrific.cxx
+++ b/libraries/TGRSIAnalysis/TTrific/TTrific.cxx
@@ -8,38 +8,33 @@ ClassImp(TTrific)
 /// \endcond
 
 //declaration of static variables that won't change from event to event
-Int_t TTrific::gridX = 0;
-Int_t TTrific::gridY = 0;
-
-
-//variables that only need to be calculated once per trific event
-TVector3 TTrific::particle = TVector3(0,0,0);
-
-Int_t TTrific::range = 0;
+Int_t TTrific::fGridX = 0;
+Int_t TTrific::fGridY = 0;
 
 //declaration of constant variables
 
 //grid parameters for TRIFIC
-//double TTrific::xmm[12]={-42,-27,-21,-15,-9,-3,3,9,15,21,27,42};
-const double TTrific::xmm[12]={-33,-27,-21,-15,-9,-3,3,9,15,21,27,33}; //mm distance to the middle of each wire set readout from centre of grid
+//double TTrific::fXmm[12]={-42,-27,-21,-15,-9,-3,3,9,15,21,27,42};
+const double TTrific::fXmm[12]={-33,-27,-21,-15,-9,-3,3,9,15,21,27,33}; //mm distance to the middle of each wire set readout from centre of grid
 //double TTrific::xW[12]={12,3,3,3,3,3,3,3,3,3,3,12}; //number of wires in eachreadout set
 
-//double TTrific::ymm[12]={48,36,28,20,12,4,-4,-12,-20,-28,-36,-48};
-const double TTrific::ymm[12]={42,36,28,20,12,4,-4,-12,-20,-28,-36,-42};
+//double TTrific::fYmm[12]={48,36,28,20,12,4,-4,-12,-20,-28,-36,-48};
+const double TTrific::fYmm[12]={42,36,28,20,12,4,-4,-12,-20,-28,-36,-42};
 //double TTrific::yW[12]={8,4,4,4,4,4,4,4,4,4,4,8};//number of wires, 2 mm spacing
 
 //angle that grids are offset by (in rads)
-const double TTrific::angle = (60./180.)*TMath::Pi();
-const TVector3 TTrific::normalGridVec = TVector3(0,-TMath::Cos(angle),TMath::Sin(angle)); //vector that points normal to the grid
+const double TTrific::fAngle = (60./180.)*TMath::Pi();
+const TVector3 TTrific::fNormalGridVec = TVector3(0,-TMath::Cos(fAngle),TMath::Sin(fAngle)); //vector that points normal to the grid
 
 //normal to the faces
 //double spacing = 10.0; //mm between each grid
 //double initialSpacing = 20.0; //mm from the window to the first grid
 
 //in cartesian coordinates
-const double TTrific::spacingCart = 13.0; //mm
-const double TTrific::initialSpacingCart = 28.0; //mm
-double TTrific::targetToWindowCart = 50.0; //mm. Non-constant static that represents the target to window distance. Will be different depending on SHARC, TIP, etc
+const double TTrific::fSpacingCart = 13.0; //mm
+const double TTrific::fInitialSpacingCart = 28.0; //mm
+double TTrific::fTargetToWindowCart = 700.0; //mm. Non-constant static that represents the target to window distance. Will be different depending on SHARC, TIP, etc
+//can be changed via SetSharc(), SetTip(), SetCustomTargetChamber().
 
 bool TTrific::fSetCoreWave = false;
 
@@ -81,7 +76,7 @@ TTrific::~TTrific()
 void TTrific::Print(Option_t*) const
 {
 	// Prints out TTrific members, currently does nothing.
-	//printf("%lu fHits\n", fHits.size());
+	printf("%lu fHits\n", fHits.size());
 	printf("%lu xHits\n",fXFragments.size());
 	printf("%lu yHits\n",fYFragments.size());
 	printf("%lu singHits\n",fSingFragments.size());
@@ -102,21 +97,17 @@ void TTrific::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel
 	//this is based on the ArraySubPosition value of the hit. 
 	switch(chan->GetMnemonic()->ArraySubPosition()){
 		case TMnemonic::EMnemonic::kX:
-			//fXFragments.push_back(hit);
-			fXFragments.push_back(std::move(hit));
+			fXFragments.push_back(hit);
 			break;
 		case TMnemonic::EMnemonic::kY:
-			//fYFragments.push_back(hit);
-			fYFragments.push_back(std::move(hit));
+			fYFragments.push_back(hit);
 			break;
 		default:
-			//fSingFragments.push_back(hit);
-			fSingFragments.push_back(std::move(hit));
+			fSingFragments.push_back(hit);
 			break;
 	};
-	
-	//fHits.push_back(hit);
-	//fHits.push_back(std::move(hit));
+
+	fHits.push_back(hit);
 	
 	return;
 }
@@ -125,7 +116,7 @@ void TTrific::Clear(Option_t* option)
 {
 
 	TDetector::Clear(option);
-	//fHits.clear();
+	fHits.clear();
 	
 	fXFragments.clear(); //!
 	fYFragments.clear(); //!
@@ -134,8 +125,8 @@ void TTrific::Clear(Option_t* option)
 	fTrificBits = 0;
 
 	//clear the static event variables
-	//particle.SetXYZ(0,0,0); //!
-	//range = 0; //!
+	//fParticle.SetXYZ(0,0,0); //!
+	//fRange = 0; //!
 	
 	return;
 }
@@ -143,21 +134,17 @@ void TTrific::Clear(Option_t* option)
 void TTrific::GetXYGrid()
 {
 	//check if we have already found the X grid location yet. If so, we don't need to do it again.
-	if (!gridX){ //if gridX == 0, then this will trigger indicating that we haven't found the X grid number yet	
+	if (!fGridX){ //if fGridX == 0, then this will trigger indicating that we haven't found the X grid number yet	
 		if (fXFragments.size()){ //we have to have an x-grid hit in this event to determine the x-grid number
 			 TTrificHit *hit = fXFragments.at(0);
-			 //TTrificHit *trifXHit = static_cast<TTrificHit*>(hit);
-			 //gridX = trifXHit->GetDetector();
-			 gridX = hit->GetDetector();
+			 fGridX = hit->GetDetector();
 		}
 	}
 	//check if we have already found the Y grid location yet. If so, we don't need to do it again.
-	if (!gridY){ //if gridY == 0, then this will trigger indicating that we haven't found the Y grid number yet
+	if (!fGridY){ //if fGridY == 0, then this will trigger indicating that we haven't found the Y grid number yet
 		if (fYFragments.size()){//we have to have an y-grid hit in this event to determine the y-grid number
 			 TTrificHit *hit = fYFragments.at(0);
-			 //TTrificHit *trifYHit = static_cast<TTrificHit*>(hit);
-			 //gridY = trifYHit->GetDetector();
-			 gridY = hit->GetDetector();
+			 fGridY = hit->GetDetector();
 		}	
 	}
 
@@ -169,6 +156,7 @@ TVector3 TTrific::GetPosition(Int_t detectorNumber)
 	//this is called on a TRIFIC hit, and will use the GetPosition() function below to calculate
 	//the x,y,z position of the hit at that grid number
 	//gives outputs in (x,y,z) in cartesian (beam) coordinates
+	// the coordinates (0,0,0) correspond to the centre of the target location, where (presumably) the beam is hitting the target
 
 	//detectorNumber is indexed at 1. 
 
@@ -176,11 +164,14 @@ TVector3 TTrific::GetPosition(Int_t detectorNumber)
 	if (24 < detectorNumber || 1 > detectorNumber) return TVector3(-1,-1,-1*abs(detectorNumber));
 	//-1*abs(detNum) ensures we return a value of (-1,-1,-#), which indicates a problem
 
-	double zCart = initialSpacingCart + spacingCart*detectorNumber; //cartesian distance to the grid of choice in the z-direction
-	//this ignores the extra (or lack of) Z due to the tilt of the grids
-	//this also only gives the window to grid distance. If you want the target to grid distance, need to add the targetToWindowCart variable too
-
 	TVector3 vec = TTrific::GetPosition();
+
+	//check if TTrific::GetPosition() returned an error vector for bad reconstruction. If so, we don't need to do anything more and can return an error vector
+	if (TVector3(-100,-100,-100) == vec) return vec; //this vector should be well outside expected XY coordinates
+
+	double zCart = fTargetToWindowCart + fInitialSpacingCart + fSpacingCart*detectorNumber; //cartesian distance to the grid of choice in the z-direction
+	//this ignores the extra (or lack of) Z due to the tilt of the grids
+	//this includes the target-to-window distance. This can be set via SetSharc() or SetTip() (or via other yet-defined functions)
 
 	zCart += zCart*vec.Y()/(TMath::Sqrt(3)-vec.Y()); //this adds (or subtracts) the extra Z distance (Z') due to the offset in Y (which are tilted at 30 degs. from vertical)
 	//notes on geometry: 30-60-90 triangle, so Y=sqrt(3)*Z', and Y/(Z+Z') = tan(theta)
@@ -197,19 +188,19 @@ TVector3 TTrific::GetPosition()
 	//that represents the TRIFIC event
 
 	//check if we've already calculated the position for this event. If so, just return it. If not, then reset the position variable.
-	if (fTrificBits.TestBit(ETrificBits::kPositionCalculated)) return particle;
-	else particle.SetXYZ(0,0,0);
+	if (fTrificBits.TestBit(ETrificBits::kPositionCalculated)) return fParticle;
+	else fParticle.SetXYZ(0,0,0);
+	//flag that we're going to (try to at least) calculate the position vector for this event
+	fTrificBits.SetBit(ETrificBits::kPositionCalculated,true);
 
 	//Get the grids that are the X and Y grids in this setup
 	GetXYGrid();
 
 	//if we don't have both an x and y grid hit in this event, position reconstruction won't be possible.
 	if(0 == fXFragments.size() || 0 == fYFragments.size()){
-		//flag that we've (tried to) calculated the position for this event
-		fTrificBits.SetBit(ETrificBits::kPositionCalculated,true);
 		//return an error vector
-		particle.SetXYZ(-1,-1,-1);
-		return particle;
+		fParticle.SetXYZ(-100,-100,-100);
+		return fParticle;
 	} 
 
 	double xMean = 0.0;
@@ -217,14 +208,14 @@ TVector3 TTrific::GetPosition()
 
 	std::vector<int> hitXDets; //vector to hold the x-segments that have a nonzero hit in them
 
-	for (auto i: fXFragments){
+	for (auto hit: fXFragments){
 		//TDetectorHit *hit = fXFragments.at(i);
-		TDetectorHit *hit = i;
+		//TDetectorHit *hit = i;
 		Int_t seg = hit->GetSegment();
 		
 		if (3 > hit->GetEnergy()) continue; //arbitrary threshold to avoid weird E<0 events
 		
-		xMean += xmm[seg]*hit->GetEnergy();
+		xMean += fXmm[seg]*hit->GetEnergy();
 		xEngTotal += hit->GetEnergy();
 		
 		hitXDets.push_back(seg);
@@ -233,11 +224,9 @@ TVector3 TTrific::GetPosition()
 	//check if hitXDets.size() is zero. This happens when we have an x-grid hit or hits, but the energy for all hits is below our arbitrary "noise" threshold.
 	//without this, the function will seg-fault when it tries to check for the continuity
 	if (!hitXDets.size()){
-		//flag that we've (tried to) calculated the position for this event
-		fTrificBits.SetBit(ETrificBits::kPositionCalculated,true);
 		//return an error vector
-		particle.SetXYZ(-2,-2,-2);
-		return particle;
+		fParticle.SetXYZ(-100,-100,-100);
+		return fParticle;
 	}
 
 	//to check for hit continuity in the grids, we need to sort the vector of segments and then check that every segment
@@ -248,20 +237,12 @@ TVector3 TTrific::GetPosition()
 
 	std::sort(hitXDets.begin(),hitXDets.end());
 
-	//this will search through the sorted vector to ensure continuity
-	if (1 < hitXDets.size()){ //don't need to check for continuity if we only have 1 x-hit
-		for (auto i = hitXDets[0]+1; i< hitXDets[hitXDets.size()-1]; i++){ 
-			//we don't need to start at hitXDets[0] because we know it is there. 
-			//we don't need to go all the way to and include hitXDets[hitXDets.size()-1] because we know it is there too.
-			if(std::find(hitXDets.begin(),hitXDets.end(),i) == hitXDets.end()){
-				//flag that we've (tried to) calculated the position for this event
-				fTrificBits.SetBit(ETrificBits::kPositionCalculated,true);
-				//return an error vector
-				particle.SetXYZ(-3,-3,-3);
-				return particle;
-			} 
-		}
-	}
+	for (unsigned int i = 1; i< hitXDets.size(); i++){ //note: this currently just rejects pileup events outright. The class will be modified later to deal with pileup properly
+    	if(hitXDets[i] != hitXDets[i-1]+1){
+        	fParticle.SetXYZ(-100,-100,-100);
+        	return fParticle;
+   		}
+	} 
 
 	//divide weighted mean by total energy
 	xMean /= xEngTotal;
@@ -273,13 +254,13 @@ TVector3 TTrific::GetPosition()
 
 	std::vector<int> hitYDets; //vector to hold the y-segments that have a nonzero hit in them
 
-	for (auto i: fYFragments){
-		TDetectorHit *hit = i;
+	for (auto hit: fYFragments){
+		//TDetectorHit *hit = i;
 		Int_t seg = hit->GetSegment();
 		
 		if (3 > hit->GetEnergy()) continue; //arbitrary threshold to avoid weird E<0 events
 		
-		yMean += ymm[seg]*hit->GetEnergy();
+		yMean += fYmm[seg]*hit->GetEnergy();
 		yEngTotal += hit->GetEnergy();
 		
 		hitYDets.push_back(seg);
@@ -288,59 +269,48 @@ TVector3 TTrific::GetPosition()
 	//check if hitYDets.size() is zero. This happens when we have an y-grid hit or hits, but the energy for all hits is below our arbitrary "noise" threshold.
 	//without this, the function will seg-fault when it tries to check for the continuity
 	if (!hitYDets.size()){
-		//flag that we've (tried to) calculated the position for this event
-		fTrificBits.SetBit(ETrificBits::kPositionCalculated,true);
 		//return an error vector
-		particle.SetXYZ(-2,-2,-2);
-		return particle;
+		fParticle.SetXYZ(-100,-100,-100);
+		return fParticle;
 	}
 
-	//check again for continuit
+	//check again for continuity
 
 	std::sort(hitYDets.begin(),hitYDets.end());
 
 	//this will search through the sorted vector to ensure continuity
-	if (1 < hitYDets.size()){ //don't need to check for continuity if we only have 1 y-hit
-		for (auto i = hitYDets[0]+1; i< hitYDets[hitYDets.size()-1]; i++){ 
-			//we don't need to start at hitYDets[0] because we know it is there. 
-			//we don't need to go all the way to and include hitYDets[hitYDets.size()-1] because we know it is there too.
-			if(std::find(hitYDets.begin(),hitYDets.end(),i) == hitYDets.end()){
-				//flag that we've (tried to) calculated the position for this event
-				fTrificBits.SetBit(ETrificBits::kPositionCalculated,true);
-				//return an error vector
-				particle.SetXYZ(-3,-3,-3);
-				return particle;
-			} 
-		}
-	}
+	for (unsigned int i = 1; i< hitYDets.size(); i++){
+    	if(hitYDets[i] != hitYDets[i-1]+1){ //again, this rejects pileup events
+        	fParticle.SetXYZ(-100,-100,-100);
+        	return fParticle;
+   		}
+	} 
 
 	//divide weighted mean by total energy
 	yMean /= yEngTotal;
 
 	//convert them into cartesion coordinates 
-	double yCart = yMean*TMath::Sin(angle); //shifts from grid coordinates to XYZ coordinates
-	double zYCart = initialSpacingCart + spacingCart*gridY+yMean*TMath::Cos(angle); //add the initial distance from the window to the grid, plus the number of gaps between the initial grid and the Y grid, plus the extra z-amount due to the hit location
-	double zXCart = initialSpacingCart + spacingCart*gridX; //adds the initial distance from window to grid, plus gaps until the x grid. No angle dependence since the grids aren't shifted in angle in x-direction
+	double yCart = yMean*TMath::Sin(fAngle); //shifts from grid coordinates to XYZ coordinates
+	double zYCart = fTargetToWindowCart + fInitialSpacingCart + fSpacingCart*fGridY+yMean*TMath::Cos(fAngle); //add the initial distance from target to grid, window to the grid, plus the number of gaps between the initial grid and the Y grid, plus the extra z-amount due to the hit location
+	double zXCart = fTargetToWindowCart + fInitialSpacingCart + fSpacingCart*fGridX; //adds the initial distance from target to grid, window to grid, plus gaps until the x grid. No angle dependence since the grids aren't shifted in angle in x-direction
 
 	double tanX = xMean/zXCart; //determine tangent of the angle in the XY plane
 	double tanY = yCart/zYCart; //tan of angle in YZ plane
 
-	//the particle trajectory below is working under the assumption that the beam is centered and hitting the window at exactly (0,0,0). 
+	//the particle trajectory below is working under the assumption that the beam is centered and hitting the target at exactly (0,0,0)
 	//while this may not be 100% true, the beam should be tuned enough that any deviations from that will be small
 
-	particle.SetXYZ(tanX,tanY,1); //unnormalized "unit" vector of the particle's trajectory.
+	fParticle.SetXYZ(tanX,tanY,1); //unnormalized "unit" vector of the particle's trajectory.
 	// "X" and "Y" coordinates are the tangent of the angles of the trajectory in the XY and YZ planes, respectively
+	//this is all done relative to the target centre
 
 	//TVector3 particleCart = TVector3(xMean,yCart,1); //this makes the vector in cartesian as opposed to angles.
 
-	//double ratioZX = 1./normalGridVec.Dot(particle.Unit()); //the Z->R corretion factor
+	//double ratioZX = 1./fNormalGridVec.Dot(fParticle.Unit()); //the Z->R corretion factor
 
-	//particle.Print();
+	//fParticle.Print();
 
-	//flag that we've calculated the position
-	fTrificBits.SetBit(ETrificBits::kPositionCalculated,true);
-
-	return particle;
+	return fParticle;
 }
 
 Int_t TTrific::GetRange()
@@ -349,13 +319,13 @@ Int_t TTrific::GetRange()
 	//can't just use the size of fHits because there is no guarantee that every
 	//grid gets an event, plus the XY position grids may have multiplicity>1
 
-	//check if we've already calculated the range for this event. If so, return it. If not, we need to reset the range.
-	if (fTrificBits.TestBit(ETrificBits::kRangeCalculated)) return range;
-	else range=0;
+	//check if we've already calculated the fRange for this event. If so, return it. If not, we need to reset the range.
+	if (fTrificBits.TestBit(ETrificBits::kRangeCalculated)) return fRange;
+	else fRange=0;
 
 	//first we'll check the single grid fragment, since there are more of them and they extend further
 	for (auto hit: fSingFragments){
-		if(hit->GetDetector() > range) range = hit->GetDetector();		
+		if(hit->GetDetector() > fRange) fRange = hit->GetDetector();		
 	}
 	//check if the range is less than the furthest position grid. If so, we need to check that the range isn't at the x or y grid
 	//this was changed because there is no guarantee that the x and y grids will stay at positions 3 and 5, so this is generic
@@ -364,17 +334,17 @@ Int_t TTrific::GetRange()
 	GetXYGrid();
 
 	//check if the range is less than the max of the grid numbers+1. The +1 is because the higher grid number will be at std::max(xGrid,yGrid) by default
-	if (range < std::max(gridX,gridY)+1){
+	if (fRange < std::max(fGridX,fGridY)+1){
 
-		if (range < gridX && fXFragments.size()) range = gridX; //we need to check if the current range is less than the x grid AND that there is an x-grid hit in this event
-		if (range < gridY && fYFragments.size()) range = gridY; //we need to check if the current range is less than the y grid AND that there is a y-grid hit in this event
+		if (fRange < fGridX && fXFragments.size()) fRange = fGridX; //we need to check if the current range is less than the x grid AND that there is an x-grid hit in this event
+		if (fRange < fGridY && fYFragments.size()) fRange = fGridY; //we need to check if the current range is less than the y grid AND that there is a y-grid hit in this event
 	} //there may be a problem here if fXFragments.size() != 0 (or Y frags too) but all the fragments have E<arb cutoff. However, GetRange() isn't referenced in any other function currently,
 	//and the likelihood of that occuring is very small I think.
 
 	//flag that we've calculated the range for this event
 	fTrificBits.SetBit(ETrificBits::kRangeCalculated,true);
 
-	return range;
+	return fRange;
 }
 
 /*

--- a/libraries/TGRSIAnalysis/TTrific/TTrificHit.cxx
+++ b/libraries/TGRSIAnalysis/TTrific/TTrificHit.cxx
@@ -50,6 +50,6 @@ TVector3 TTrificHit::GetPosition() const
 	//calling GetPosition() on a TRIFIC hit will return the position vector to the centre of the grid
 	//calling TTrific::GetPosition(det) will give the vector to the position itself.
 
-	return TVector3(0,0,TTrific::targetToWindowCart+TTrific::initialSpacingCart+TTrific::spacingCart*GetDetector());
+	return TVector3(0,0,TTrific::fTargetToWindowCart+TTrific::fInitialSpacingCart+TTrific::fSpacingCart*GetDetector());
 }
 


### PR DESCRIPTION
Added in some optimization of TRIFIC functions. Added back in fHits vector after discussion from [GRSISort/1196](https://github.com/GRIFFINCollaboration/GRSISort/issues/1196).  Fixed member variable names to be consistent with coding standards. Changed the output from GetPosition() and GetPosition(detNumber) when bad position reconstruction happens. 