### PR TITLE
Fixed crosstalk correction

### DIFF
--- a/include/TLaBrHit.h
+++ b/include/TLaBrHit.h
@@ -46,7 +46,7 @@ public:
 public:
    void Clear(Option_t* opt = "") override;       //!<!
    void Print(Option_t* opt = "") const override; //!<!
-   void     Copy(TObject&) const override;        //!<!
+   void Copy(TObject&) const override;            //!<!
    TVector3 GetPosition(Double_t dist) const override;
    TVector3 GetPosition() const override;
 

--- a/include/TPacesHit.h
+++ b/include/TPacesHit.h
@@ -39,7 +39,7 @@ public:
 public:
    void Clear(Option_t* opt = "") override;            //!<!
    void Print(Option_t* opt = "") const override;      //!<!
-   void     Copy(TObject&) const override;             //!<!
+   void Copy(TObject&) const override;            //!<!
    TVector3 GetPosition(Double_t dist) const override; //!<!
    TVector3 GetPosition() const override;              //!<!
 

--- a/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
@@ -46,30 +46,30 @@ Double_t TGRSIDetectorHit::GetTime(const ETimeFlag&, Option_t*) const
    TChannel* channel = GetChannel();
    if(channel == nullptr) {
       Error("GetTime", "No TChannel exists for address 0x%08x", GetAddress());
-      return SetTime(static_cast<Double_t>((GetTimeStamp()) + gRandom->Uniform()));
+		return SetTime(static_cast<Double_t>(((GetTimeStamp()) + gRandom->Uniform()) * GetTimeStampUnit()));
    }
 	
    switch(static_cast<EDigitizer>(channel->GetDigitizerType())) {
 		Double_t dTime;
 		case EDigitizer::kGRF16:
-		dTime = (GetTimeStamp() & (~0x3ffff))*GetTimeStampUnit() +
-		channel->CalibrateCFD((GetCfd() + gRandom->Uniform()) / 1.6); // CFD is in 10/16th of a nanosecond
-		return SetTime(dTime - channel->GetTZero(GetEnergy()) - channel->GetTimeOffset());
+			// we need to zero the lowest 18 bits of the timestamp as those are included in the CFD value
+			// TODO: what happens close to the wrap-around of those 18 bits??? This only happens every 2^18 * 10e-8 so 2.5 ms so 400 Hz
+			dTime = (GetTimeStamp() & (~0x3ffff)) * GetTimeStampUnit() + channel->CalibrateCFD((GetCfd() + gRandom->Uniform()) / 1.6); // CFD is in 10/16th of a nanosecond
+			return SetTime(dTime - channel->GetTZero(GetEnergy()) - channel->GetTimeOffset());
 		case EDigitizer::kGRF4G:
-		dTime = GetTimeStamp()*GetTimeStampUnit() + channel->CalibrateCFD((static_cast<Int_t>(fCfd) >> 22) + ((static_cast<Int_t>(fCfd) & 0x3fffff) + gRandom->Uniform()) / 256.);
-		return SetTime(dTime - channel->GetTZero(GetEnergy()) - channel->GetTimeOffset());
+			dTime = GetTimeStamp()*GetTimeStampUnit() + channel->CalibrateCFD((static_cast<Int_t>(fCfd) >> 22) + ((static_cast<Int_t>(fCfd) & 0x3fffff) + gRandom->Uniform()) / 256.);
+			return SetTime(dTime - channel->GetTZero(GetEnergy()) - channel->GetTimeOffset());
 		case EDigitizer::kTIG10:
-		dTime = (GetTimeStamp() & (~0x7fffff))*GetTimeStampUnit() +
-		channel->CalibrateCFD((GetCfd() + gRandom->Uniform()) / 1.6); // CFD is in 10/16th of a nanosecond
-		//channel->CalibrateCFD((GetCfd() & (~0xf) + gRandom->Uniform()) / 1.6); // PBender suggests this.
-		return SetTime(dTime - channel->GetTZero(GetEnergy()) - channel->GetTimeOffset());
+			dTime = (GetTimeStamp() & (~0x7fffff))*GetTimeStampUnit() +	channel->CalibrateCFD((GetCfd() + gRandom->Uniform()) / 1.6); // CFD is in 10/16th of a nanosecond
+			//channel->CalibrateCFD((GetCfd() & (~0xf) + gRandom->Uniform()) / 1.6); // PBender suggests this.
+			return SetTime(dTime - channel->GetTZero(GetEnergy()) - channel->GetTimeOffset());
       case EDigitizer::kCaen:
-      //10 bit CFD for 0-2ns => divide by 512
-      dTime = GetTimeStamp()*GetTimeStampUnit() + channel->CalibrateCFD((GetCfd() + gRandom->Uniform()) / 512.);
-      return SetTime(dTime - channel->GetTZero(GetEnergy()) - channel->GetTimeOffset());
+			//10 bit CFD for 0-2ns => divide by 512
+			dTime = GetTimeStamp()*GetTimeStampUnit() + channel->CalibrateCFD((GetCfd() + gRandom->Uniform()) / 512.);
+			return SetTime(dTime - channel->GetTZero(GetEnergy()) - channel->GetTimeOffset());
 		default:
-		dTime = static_cast<Double_t>(((GetTimeStamp()) + gRandom->Uniform())*GetTimeStampUnit());
-		return SetTime(dTime - channel->GetTZero(GetEnergy()) - channel->GetTimeOffset());
+			dTime = static_cast<Double_t>(((GetTimeStamp()) + gRandom->Uniform())*GetTimeStampUnit());
+			return SetTime(dTime - channel->GetTZero(GetEnergy()) - channel->GetTimeOffset());
 	}
    return 0.;
 }

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
@@ -631,6 +631,8 @@ void TGriffin::FixHighGainCrossTalk()
 
 void TGriffin::FixCrossTalk(const EGainBits& gain_type)
 {
+	if(!TGRSIOptions::AnalysisOptions()->IsCorrectingCrossTalk()) return;
+
 	auto& hit_vec = GetHitVector(gain_type);
 	if(hit_vec.size() < 2) {
 		SetCrossTalk(gain_type, true);
@@ -640,13 +642,10 @@ void TGriffin::FixCrossTalk(const EGainBits& gain_type)
 		static_cast<TGriffinHit*>(hit)->ClearEnergy();
 	}
 
-	// why is this check done here? Shouldn't this be the first thing to check?
-	if(TGRSIOptions::AnalysisOptions()->IsCorrectingCrossTalk()) {
-		for(auto& one : hit_vec) {
-			for(auto& two : hit_vec) {
-				one->SetEnergy(TGriffin::CTCorrectedEnergy(static_cast<TGriffinHit*>(one), static_cast<TGriffinHit*>(two)));
-				two->SetEnergy(TGriffin::CTCorrectedEnergy(static_cast<TGriffinHit*>(two), static_cast<TGriffinHit*>(one)));
-			}
+	for(auto& one : hit_vec) {
+		for(auto& two : hit_vec) {
+			one->SetEnergy(TGriffin::CTCorrectedEnergy(static_cast<TGriffinHit*>(one), static_cast<TGriffinHit*>(two)));
+			//two->SetEnergy(TGriffin::CTCorrectedEnergy(static_cast<TGriffinHit*>(two), static_cast<TGriffinHit*>(one)));
 		}
 	}
 	SetCrossTalk(gain_type, true);

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
@@ -70,12 +70,11 @@ void TGriffinHit::Clear(Option_t* opt)
 void TGriffinHit::Print(Option_t*) const
 {
    // Prints the Detector Number, Crystal Number, Energy, Time and Angle.
-   printf("Griffin Detector: %i\n", GetDetector());
-   printf("Griffin Crystal:  %i\n", GetCrystal());
-   printf("Griffin Energy:   %lf\n", GetEnergy());
-   printf("Griffin hit time:   %lf\n", GetTime());
-   printf("Griffin hit TV3 theta: %.2f\tphi%.2f\n", GetPosition().Theta() * 180 / (3.141597),
-          GetPosition().Phi() * 180 / (3.141597));
+	std::cout<<"Griffin Detector: "<<GetDetector()<<std::endl
+		      <<"Griffin Crystal:  "<<GetCrystal()<<std::endl
+            <<"Griffin Energy:   "<<GetEnergy()<<std::endl
+            <<"Griffin hit time:   "<<GetTime()<<", TS (in ns) "<<GetTimeStampNs()<<", TS "<<fTimeStamp<<std::endl
+            <<"Griffin hit TV3 theta: "<<GetPosition().Theta() * 180 / (3.141597)<<" \tphi: "<<GetPosition().Phi() * 180 / (3.141597)<<std::endl;
 }
 
 TVector3 TGriffinHit::GetPosition(double dist) const


### PR DESCRIPTION
The TGriffin::FixCrossTalk function was applying the crosstalk correction twice, thus over correcting the cross talk.

Also made some cosmetic changes like fixing indentation, replacing printf with std::cout, and removing unnecessary calls to the GetTimeStampUnit function when no channel is available.