### PR TITLE
Some small changes

### DIFF
--- a/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
@@ -463,26 +463,27 @@ void TGriffin::AddFragment(const std::shared_ptr<const TFragment>& frag, TChanne
 		return;
 	}
 
-   switch(mnemonic->SubSystem()) {
-		case TMnemonic::EMnemonic::kG:
+	if(mnemonic->SubSystem() != TMnemonic::EMnemonic::kG) {
+		std::cerr<<__PRETTY_FUNCTION__<<": not a GRIFFIN detector: "<<static_cast<std::underlying_type<TMnemonic::EMnemonic>::type>(mnemonic->SubSystem())<<std::endl;
+		return;
+	}
+
+	// only create the hit if we have a HPGe signal (A or B), not a suppressor (S)
+	switch(mnemonic->OutputSensor()) {
+		case TMnemonic::EMnemonic::kA:
 			{
 				TGriffinHit* hit = new TGriffinHit(*frag);
-				switch(mnemonic->OutputSensor()) {
-					case TMnemonic::EMnemonic::kA:
-						GetHitVector(EGainBits::kLowGain).push_back(hit);
-						break;
-					case TMnemonic::EMnemonic::kB:
-						GetHitVector(EGainBits::kHighGain).push_back(hit);
-						break;
-					default:
-						break;
-				};
+				GetHitVector(EGainBits::kLowGain).push_back(hit);
 			}
 			break;
-			//     case TMnemonic::EMnemonic::kS :
-			// do supressor stuff in the future
-			//      break;
+		case TMnemonic::EMnemonic::kB:
+			{
+				TGriffinHit* hit = new TGriffinHit(*frag);
+				GetHitVector(EGainBits::kHighGain).push_back(hit);
+			}
+			break;
 		default:
+			std::cout<<"output sensor "<<static_cast<std::underlying_type<TMnemonic::EMnemonic>::type>(mnemonic->OutputSensor())<<", skipping it"<<std::endl;
 			break;
 	};
 }

--- a/libraries/TGRSIDataParser/TGRSIDataParser.cxx
+++ b/libraries/TGRSIDataParser/TGRSIDataParser.cxx
@@ -157,7 +157,7 @@ int TGRSIDataParser::TigressDataToFragment(uint32_t* data, int size, std::shared
 		switch(type) {
 			case 0x0: // raw wave forms.
 				{
-					TChannel* chan = TChannel::GetChannel(eventFrag->GetAddress());
+					TChannel* chan = TChannel::GetChannel(eventFrag->GetAddress(), false);
 					if(!fNoWaveforms) {
 						SetTIGWave(value, eventFrag);
 					}
@@ -540,7 +540,7 @@ int TGRSIDataParser::GriffinDataToFragment(uint32_t* data, int size, EBank bank,
 	if(eventFrag->GetDetectorType() == 0xf) {
 		// a scaler event (trigger or deadtime) has 8 words (including header and trailer), make sure we have at least
 		// that much left
-		TChannel* chan = TChannel::GetChannel(eventFrag->GetAddress());
+		TChannel* chan = TChannel::GetChannel(eventFrag->GetAddress(), false);
 		if((chan != nullptr) && strncmp("RF", chan->GetName(), 2) == 0){
 			//JW: RF event, stored as a scaler containing fit paramters 
 			//in recent (2019 and later) GRIF-16 firmware revisions.
@@ -710,7 +710,7 @@ int TGRSIDataParser::GriffinDataToFragment(uint32_t* data, int size, EBank bank,
 						}
 						eventFrag->SetCfd(tmpCfd[0]);
 						if(fRecordDiag) {
-							TParsingDiagnostics::Get()->GoodFragment(eventFrag);
+							TParsingDiagnostics::Get()->GoodFragment(eventFrag->GetDetectorType());
 						}
 						fFragmentMap.Add(eventFrag, tmpCharge, tmpIntLength);
 						return x;
@@ -733,7 +733,7 @@ int TGRSIDataParser::GriffinDataToFragment(uint32_t* data, int size, EBank bank,
 						eventFrag->SetKValue(tmpIntLength[h]);
 						eventFrag->SetCfd(tmpCfd[h]);
 						if(fRecordDiag) {
-							TParsingDiagnostics::Get()->GoodFragment(eventFrag);
+							TParsingDiagnostics::Get()->GoodFragment(eventFrag->GetDetectorType());
 						}
 						if(fState == EDataParserState::kGood) {
 							if(fOptions->ReconstructTimeStamp()) {
@@ -2046,7 +2046,7 @@ int TGRSIDataParser::EmmaMadcDataToFragment(uint32_t* data, int size, std::share
 						std::shared_ptr<TFragment> transferfrag = std::make_shared<TFragment>(*eventFrag);
 						transferfrag->SetCharge(static_cast<Int_t>(adcdata));
 						transferfrag->SetAddress(0x800000 + adcchannel);
-						TChannel* chan = TChannel::GetChannel(transferfrag->GetAddress());
+						TChannel* chan = TChannel::GetChannel(transferfrag->GetAddress(), false);
 						if(chan == nullptr) {
 							chan = fChannel;
 						}

--- a/libraries/TGRSIFormat/TGRSIMnemonic.cxx
+++ b/libraries/TGRSIFormat/TGRSIMnemonic.cxx
@@ -204,7 +204,7 @@ double TGRSIMnemonic::GetTime(Long64_t timestamp, Float_t cfd, double energy, co
 {
    if(channel == nullptr) {
       Error("GetTime", "No TChannel provided");
-		return static_cast<Double_t>(((timestamp) + gRandom->Uniform()) * channel->GetTimeStampUnit());
+		return static_cast<Double_t>((timestamp) + gRandom->Uniform());
    }
 	
    switch(static_cast<EDigitizer>(channel->GetDigitizerType())) {

--- a/libraries/TMidas/TMidasFile.cxx
+++ b/libraries/TMidas/TMidasFile.cxx
@@ -974,7 +974,7 @@ void TMidasFile::SetTIGOdb()
    }
 
    for(size_t x = 0; x < address.size(); x++) {
-      TChannel* tempChan = TChannel::GetChannel(address.at(x)); // names.at(x).c_str());
+      TChannel* tempChan = TChannel::GetChannel(address.at(x), false); // names.at(x).c_str());
       if(tempChan == nullptr) {
          tempChan = new TChannel();
       }


### PR DESCRIPTION
- No missing channel warnings for TIG Odb
- Removed trying to access timestamp unit from channel if no channel is found
- Fixed bug with parsing diagnostics in TGRSIDataParser
- GRIFFIN: Changed from if check for subsystem 'g' to switch statement