### PR TITLE
Smaller bug fixes

### DIFF
--- a/libraries/TGRSIFormat/TGRSIDetectorInformation.cxx
+++ b/libraries/TGRSIFormat/TGRSIDetectorInformation.cxx
@@ -98,6 +98,10 @@ void TGRSIDetectorInformation::Clear(Option_t*)
 void TGRSIDetectorInformation::Set()
 {
    /// Sets the run info. This figures out what systems are available.
+	if(TChannel::GetChannelMap() == nullptr) {
+		std::cerr<<RED<<"TGRSIDetectorInformation::Set(): Failed to get channel map!"<<RESET_COLOR<<std::endl;
+		return;
+	}
    for(auto iter = TChannel::GetChannelMap()->begin(); iter != TChannel::GetChannelMap()->end(); iter++) {
       std::string channelname = iter->second->GetName();
 

--- a/libraries/TMidas/TMidasFile.cxx
+++ b/libraries/TMidas/TMidasFile.cxx
@@ -700,14 +700,15 @@ void TMidasFile::SetFileOdb()
       node = node->GetNextNode();
    }
    if(expt.compare("tigress") == 0) {
-      //		fIamTigress = true;
       SetTIGOdb();
-   } else if(expt.compare("griffin") == 0) {
-      //		fIamGriffin = true;
+   } else if(expt.find("grif") != std::string::npos) {
+		// for GRIFFIN the experiment name might be griffin, grifstor, grifalt, etc.
       SetGRIFFOdb();
    } else if(expt.compare("tigdaq") == 0) { //New TIGRESS DAQ
       SetTIGDAQOdb();
-   }
+   } else {
+		std::cerr<<RED<<"Unknown experiment name \""<<expt<<"\", ODB won't be read!"<<RESET_COLOR<<std::endl;
+	}
 #endif
 }
 
@@ -882,6 +883,11 @@ void TMidasFile::SetGRIFFOdb()
       return;
    }
    std::vector<int> durations = fOdb->ReadIntArray(node);
+
+	if(durations.size() != ppgCodes.size()) {
+      std::cerr<<"Mismatching sizes of ppg codes ("<<ppgCodes.size()<<") and duration ("<<durations.size()<<")"<<std::endl;
+      return;
+	}
 
    TPPG::Get()->SetOdbCycle(ppgCodes, durations);
 #endif

--- a/makefile
+++ b/makefile
@@ -108,8 +108,9 @@ ROOT_LIBFLAGS := $(shell root-config --cflags --glibs)
 GRSI_LIBFLAGS := $(shell grsi-config --cflags --libs)
 
 UTIL_O_FILES    := $(patsubst %.$(SRC_SUFFIX),.build/%.o,$(wildcard util/*.$(SRC_SUFFIX)))
+ANALYSIS_O_FILES := $(patsubst %.$(SRC_SUFFIX),.build/%.o,$(wildcard myAnalysis/*.$(SRC_SUFFIX)))
 MAIN_O_FILES    := $(patsubst %.$(SRC_SUFFIX),.build/%.o,$(wildcard src/*.$(SRC_SUFFIX)))
-EXE_O_FILES     := $(UTIL_O_FILES)
+EXE_O_FILES     := $(UTIL_O_FILES) $(ANALYSIS_O_FILES)
 EXECUTABLES     := $(patsubst %.o,$(GRSISYS)/bin/%,$(notdir $(EXE_O_FILES)))
 
 HISTOGRAM_SO    := $(patsubst histos/%.$(SRC_SUFFIX),lib/lib%.so,$(wildcard histos/*.$(SRC_SUFFIX)))
@@ -146,6 +147,9 @@ docs: doxygen
 
 doxygen:
 	$(MAKE) -C $@
+
+$(GRSISYS)/bin/%: .build/myAnalysis/%.o | $(LIBRARY_OUTPUT) include/GRSIDataVersion.h lib/libGRSIData.so
+	$(call run_and_test,$(CPP) $< -o $@ $(LINKFLAGS),$@,$(COM_COLOR),$(COM_STRING),$(OBJ_COLOR) )
 
 $(GRSISYS)/bin/%: .build/util/%.o | $(LIBRARY_OUTPUT) include/GRSIDataVersion.h lib/libGRSIData.so
 	$(call run_and_test,$(CPP) $< -o $@ $(LINKFLAGS),$@,$(COM_COLOR),$(COM_STRING),$(OBJ_COLOR) )

--- a/makefile
+++ b/makefile
@@ -163,7 +163,7 @@ lib/lib%.so: $$(call lib_o_files,%) $$(call lib_dictionary,%) | include/GRSIData
 	$(call run_and_test,$(CPP) -fPIC $^ $(SHAREDSWITCH)lib$*.so $(ROOT_LIBFLAGS) $(GRSI_LIBFLAGS) -o $@,$@,$(BLD_COLOR),$(BLD_STRING),$(OBJ_COLOR) )
 
 lib/libGRSIData.so: $(LIBRARY_OUTPUT) $(MAIN_O_FILES) | include/GRSIDataVersion.h
-	$(call run_and_test,$(CPP) -fPIC $(shell $(FIND) .build/libraries -name "*.o") $(SHAREDSWITCH)lib$*.so $(ROOT_LIBFLAGS) $(GRSI_LIBFLAGS) $(MAIN_O_FILES) -o $@,$@,$(BLD_COLOR),$(BLD_STRING),$(OBJ_COLOR) )
+	$(call run_and_test,$(CPP) -fPIC $(shell $(FIND) .build/libraries -name "*.o") $(SHAREDSWITCH)lib$*.so $(ROOT_LIBFLAGS) $(MAIN_O_FILES) -o $@,$@,$(BLD_COLOR),$(BLD_STRING),$(OBJ_COLOR) )
 
 .build/%.o: %.$(SRC_SUFFIX)
 	@mkdir -p $(dir $@)

--- a/myAnalysis/.gitignore
+++ b/myAnalysis/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
Makefile:
- Not including the GRSISort libraries when compiling the GRSIData library removes a lot of the "class X already in TClassTable" messages when using grsiproof.
- Added myAnalysis sub-directory to the GRSIData directory. Any .cxx file in this directory will be compiled into an executable (similar to the util sub-directory), but unlike the util directory, no files in this directory will show up when using ```git status``` or included by ```git commit -a```.

TMidasFile:
- Added check that the size of the ppg codes and durations read from the ODB are the same.
- Changed the check for the griffin experiment name from an exact match of "griffin" to just the existence of "grif" in the name. This is because for the experiments in November 2021 experiment names such as "grifstor" or "grifalt" were used. This should hopefully also catch all future cases?

Added check for TChannel::GetChannelMap() being a null pointer in TGRSIDetectorInformation::Get().