### PR TITLE
Fixes for LaBr BGOs

### DIFF
--- a/include/TGRSIMnemonic.h
+++ b/include/TGRSIMnemonic.h
@@ -62,6 +62,8 @@ public:
 
 	double GetTime(Long64_t timestamp, Float_t cfd, double energy, const TChannel* channel) const override;
 
+	int NumericArraySubPosition() const override;
+
    void Print(Option_t* opt = "") const override;
    void Clear(Option_t* opt = "") override;
 

--- a/include/TLaBrBgo.h
+++ b/include/TLaBrBgo.h
@@ -7,12 +7,15 @@
 
 #include "Globals.h"
 #include "TBgo.h"
+#include "TLaBrBgoHit.h"
 
 class TLaBrBgo : public TBgo {
 public:
    TLaBrBgo();
    TLaBrBgo(const TLaBrBgo&);
    virtual ~TLaBrBgo();
+
+   TLaBrBgoHit* GetLaBrBgoHit(const int& i) const { return static_cast<TLaBrBgoHit*>(GetHit(i)); }
 
    TLaBrBgo& operator=(const TLaBrBgo&); //!<!
 

--- a/include/TLaBrBgoHit.h
+++ b/include/TLaBrBgoHit.h
@@ -29,7 +29,7 @@ public:
    ~TLaBrBgoHit() override;
 
    /////////////////////////		/////////////////////////////////////
-   UShort_t GetArrayNumber() const override { return (3 * (GetDetector() - 1) + GetSegment()); } //!<! the BGO of each detector has three segments
+   UShort_t GetArrayNumber() const override { return (3 * (GetDetector() - 1) + GetCrystal()); } //!<! the BGO of each detector has three segments
 
    /// \cond CLASSIMP
    ClassDefOverride(TLaBrBgoHit, 2)

--- a/libraries/TGRSIFormat/TGRSIMnemonic.cxx
+++ b/libraries/TGRSIFormat/TGRSIMnemonic.cxx
@@ -234,3 +234,41 @@ double TGRSIMnemonic::GetTime(Long64_t timestamp, Float_t cfd, double energy, co
    return 0.;
 }
 
+int TGRSIMnemonic::NumericArraySubPosition() const
+{
+	/// This function translates the crystal color to an index
+	/// B - Blue - 0, G - Green - 1, R - Red - 2, W - White - 3, default - 5
+	/// Except for the LaBr BGOs which use A - 0, B - 1, C - 2
+	/// and a default of 5
+	if(System() == ESystem::kLaBrBgo) {
+		switch(fArraySubPosition) {
+			case TMnemonic::EMnemonic::kA:
+				return 0;
+			case TMnemonic::EMnemonic::kB:
+				return 1;
+			case TMnemonic::EMnemonic::kC:
+				return 2;
+			default:
+				return 5;
+		};
+	}
+
+	switch(fArraySubPosition) {
+		case TMnemonic::EMnemonic::kB:
+			return 0;
+		case TMnemonic::EMnemonic::kG:
+			return 1;
+		case TMnemonic::EMnemonic::kR:
+			return 2;
+		case TMnemonic::EMnemonic::kW:
+			return 3;
+		default:
+			return 5;
+	};
+
+	// return statement here instead of default case
+	// to make sure compiler doesn't warn us about missing return
+	return 5;
+}
+
+


### PR DESCRIPTION
- TLaBr now has a function to return a ```TLaBrBgoHit*``` instead of only one returning a ```TDetectorHit*```.
- The TLaBrBgoHit::GetArrayNumber function now uses GetCrystal instead of GetSegment (see GRSICollaboration/GRSISort#1264).
- TGRSIMnemonic overwrites the behavior of TMnemonic::NumericArraySubPosition(). Instead of always parsing B - 0, G - 1, R - 2, and W - 3 (rest to 5), it now parses A - 0, B - 1, and C - 2 for TLaBrBgo system (same old behavior for all other systems).