### PR TITLE
Always copy waveforms for TIP hits.

### DIFF
--- a/libraries/TGRSIAnalysis/TTip/TTipHit.cxx
+++ b/libraries/TGRSIAnalysis/TTip/TTipHit.cxx
@@ -46,7 +46,7 @@ TTipHit::TTipHit(const TTipHit& rhs) : TDetectorHit()
 
 void TTipHit::Copy(TObject& rhs) const
 {
-   TDetectorHit::Copy(rhs);
+   TDetectorHit::Copy(rhs,true);
    static_cast<TTipHit&>(rhs).fFilter     = fFilter;
    static_cast<TTipHit&>(rhs).fPID        = fPID;
    static_cast<TTipHit&>(rhs).fTipChannel = fTipChannel;


### PR DESCRIPTION
As discussed [here](https://github.com/GRIFFINCollaboration/GRSISort/pull/1266), this enables waveform copying by default for TIP hits.