### PR TITLE
Copy TIP waveforms by calling TDetectorHit::CopyWave directly

### DIFF
--- a/libraries/TGRSIAnalysis/TTip/TTipHit.cxx
+++ b/libraries/TGRSIAnalysis/TTip/TTipHit.cxx
@@ -46,7 +46,8 @@ TTipHit::TTipHit(const TTipHit& rhs) : TDetectorHit()
 
 void TTipHit::Copy(TObject& rhs) const
 {
-   TDetectorHit::Copy(rhs,true);
+   TDetectorHit::Copy(rhs);
+   TDetectorHit::CopyWave(rhs); //waveforms are basically always needed (for TIP PID)
    static_cast<TTipHit&>(rhs).fFilter     = fFilter;
    static_cast<TTipHit&>(rhs).fPID        = fPID;
    static_cast<TTipHit&>(rhs).fTipChannel = fTipChannel;


### PR DESCRIPTION
This modifies the way that TTipHit copies waveforms, based on the earlier discussion in [this](https://github.com/GRIFFINCollaboration/GRSISort/pull/1266) PR.