### PR TITLE
Add fit type property to TTipHit, and set TIP hits to be CsI by default.

### DIFF
--- a/include/TTipHit.h
+++ b/include/TTipHit.h
@@ -27,12 +27,13 @@ private:
    Int_t    fFilter{0}; //
    Double_t fPID{0.};    //
    Int_t    fChiSq{0};
+   Int_t    fFitType{0};
 
    // Double_t fFastAmplitude;
    // Double_t fSlowAmplitude;
    // Double_t fGammaAmplitude;
 
-   bool csi_flag{false};
+   bool csi_flag{true};
 
    Int_t fTipChannel{0};
 
@@ -45,10 +46,11 @@ public:
    inline void SetPID(Double_t x) { fPID = x; }                //!<!
    inline void SetTipChannel(const int x) { fTipChannel = x; } //!<!
 
-   inline Int_t    GetFiterPatter() { return fFilter; }      //!<!
+   inline Int_t    GetFilterPattern() { return fFilter; }      //!<!
    inline Double_t GetPID() { return fPID; }                 //!<!
    inline Int_t    GetFitChiSq() { return fChiSq; }          //!<!
    inline Double_t GetFitTime() { return fTimeFit; }         //!<!
+   inline Int_t    GetFitType() { return fFitType; }         //!<!
    inline Double_t GetSignalToNoise() { return fSig2Noise; } //!<!
    inline Int_t    GetTipChannel() const { return fTipChannel; }   //!<!
 

--- a/libraries/TGRSIAnalysis/TTip/TTipHit.cxx
+++ b/libraries/TGRSIAnalysis/TTip/TTipHit.cxx
@@ -52,6 +52,7 @@ void TTipHit::Copy(TObject& rhs) const
    static_cast<TTipHit&>(rhs).fPID        = fPID;
    static_cast<TTipHit&>(rhs).fTipChannel = fTipChannel;
    static_cast<TTipHit&>(rhs).fTimeFit    = fTimeFit;
+   static_cast<TTipHit&>(rhs).fFitType    = fFitType;
    static_cast<TTipHit&>(rhs).fSig2Noise  = fSig2Noise;
    static_cast<TTipHit&>(rhs).fChiSq      = fChiSq;
 }
@@ -106,5 +107,6 @@ void TTipHit::SetPID(const TFragment& frag)
       fPID     = pulse.CsIPID();
       fTimeFit = pulse.CsIt0();
       fChiSq   = pulse.GetCsIChiSq();
+      fFitType = pulse.GetCsIFitType();
    }
 }


### PR DESCRIPTION
This fixes a couple of things with TIP.  For some reason, `csi_flag` defaulted to false, which was preventing CsI waveform fits when sorting an analysis tree using the `--waveform-fitting` flag.  In general, TIP hits are always CsI (there is some old data from pre-2015 where a PIN diode array was used, but AFAIK there are no plans to use it again), so it makes sense for that to be the default.  With this change, it becomes possible to fit waveforms when building the analysis tree.

Also, this adds a `GetFitType()` method, which is useful for determining which fit algorithm was used to fit a given TIP hit.  I'll be submitting a GRSISort PR soon which updates the CsI waveform fits to those used in the latest version of the SFU code, where multiple waveform fit types are tried per hit and only the best fit is retained.  Since multiple fit types will be possible, the fit type used should be made user-accessible via `GetFitType()` for diagnostic purposes.

