### PR TITLE
New TGriffinAngles class and AngularCorrelations program

### DIFF
--- a/include/TGriffinAngles.h
+++ b/include/TGriffinAngles.h
@@ -1,0 +1,48 @@
+#ifndef TGRIFFINANGLES_H
+#define TGRIFFINANGLES_H
+
+/** \addtogroup Analysis
+ *  @{
+ */
+
+////////////////////////////////////////////////////////////////////////////////
+/// 
+/// \class TGriffinAngles
+///
+/// This class provides the number of angles, their values, and the index a 
+/// specific angle is at.
+/// It is meant to be used for the angular correlation analysis.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+#include <set>
+#include <map>
+#include <functional>
+
+#include "TObject.h"
+
+class TGriffinAngles : public TObject {
+public:
+	TGriffinAngles(double distance, bool folding, bool grouping, bool addback);
+	~TGriffinAngles() {}
+
+	int Index(double angle);
+	int NumberOfAngles() const { return fAngles.size(); }
+	double Angle(int index) const { auto it = fAngles.begin(); std::advance(it, index); return *it; }
+
+	std::set<double>::iterator begin() const { return fAngles.begin(); }
+	std::set<double>::iterator end() const { return fAngles.end(); }
+
+	void Print() const;
+
+private:
+	double fRounding{0.01}; ///< we consider any angles whose difference is less than this to be equal
+	std::set<double, std::function<bool(const double&, const double&)>> fAngles; ///< set of unique angles, when grouping is used, the largest angle of the group is used!
+	std::map<double, int> fAngleMap; ///< Maps angles to indices. This is fairly straight forward without grouping, but if grouping is used multiple angles can be mapped to the same index.
+
+	/// \cond CLASSIMP
+	ClassDef(TGriffinAngles, 1)
+	/// \endcond
+};
+/*! @} */
+#endif

--- a/include/TGriffinAngles.h
+++ b/include/TGriffinAngles.h
@@ -19,29 +19,39 @@
 #include <map>
 #include <functional>
 
-#include "TObject.h"
+#include "TNamed.h"
 
-class TGriffinAngles : public TObject {
+class TGriffinAngles : public TNamed {
 public:
-	TGriffinAngles(double distance, bool folding, bool grouping, bool addback);
+	TGriffinAngles(double distance = 145., bool folding = false, bool grouping = false, bool addback = true);
 	~TGriffinAngles() {}
+
+	double Distance() { return fDistance; }
+	double Folding() { return fFolding; }
+	double Grouping() { return fGrouping; }
+	double Addback() { return fAddback; }
 
 	int Index(double angle);
 	int NumberOfAngles() const { return fAngles.size(); }
 	double Angle(int index) const { auto it = fAngles.begin(); std::advance(it, index); return *it; }
+	double AverageAngle(int index) const;
 
 	std::set<double>::iterator begin() const { return fAngles.begin(); }
 	std::set<double>::iterator end() const { return fAngles.end(); }
 
-	void Print() const;
+	void Print(Option_t* = "") const override;
 
 private:
+	double fDistance{145.}; ///< distance of detector from center of array in mmm
+	bool fFolding{false}; ///< flag indicating whether we fold our distribution around 90 degree 
+	bool fGrouping{false}; ///< flag indicating whether we group close angles together
+	bool fAddback{true}; ///< flag indicating whether we use addback
 	double fRounding{0.01}; ///< we consider any angles whose difference is less than this to be equal
-	std::set<double, std::function<bool(const double&, const double&)>> fAngles; ///< set of unique angles, when grouping is used, the largest angle of the group is used!
+	std::set<double> fAngles; ///< set of unique angles, when grouping is used, the largest angle of the group is used!
 	std::map<double, int> fAngleMap; ///< Maps angles to indices. This is fairly straight forward without grouping, but if grouping is used multiple angles can be mapped to the same index.
 
 	/// \cond CLASSIMP
-	ClassDef(TGriffinAngles, 1)
+	ClassDefOverride(TGriffinAngles, 2)
 	/// \endcond
 };
 /*! @} */

--- a/libraries/TGRSIAnalysis/TGriffin/LinkDef.h
+++ b/libraries/TGRSIAnalysis/TGriffin/LinkDef.h
@@ -1,4 +1,4 @@
-//TGriffin.h TGriffinHit.h TGriffinBgo.h TGriffinBgoHit.h
+//TGriffin.h TGriffinHit.h TGriffinBgo.h TGriffinBgoHit.h TGriffinAngles.h
 #ifdef __CINT__
 
 #pragma link off all globals;
@@ -14,5 +14,6 @@
 #pragma link C++ class TGriffin+;
 #pragma link C++ class TGriffinBgoHit+;
 #pragma link C++ class TGriffinBgo+;
+#pragma link C++ class TGriffinAngles+;
 
 #endif

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffinAngles.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffinAngles.cxx
@@ -1,0 +1,94 @@
+#include "TGriffinAngles.h"
+#include "TGriffin.h"
+
+ClassImp(TGriffinAngles)
+
+TGriffinAngles::TGriffinAngles(double distance, bool folding, bool grouping, bool addback)
+	: fAngles([this](const double& lhs, const double& rhs) { return std::abs(lhs-rhs) < fRounding; })
+{
+   // loop over all possible detector/crystal combinations
+   for(int firstDet = 1; firstDet <= 16; ++firstDet) {
+      for(int firstCry = 0; firstCry < 4; ++firstCry) {
+         for(int secondDet = 1; secondDet <= 16; ++secondDet) {
+            for(int secondCry = 0; secondCry < 4; ++secondCry) {
+               // exclude hits in the same crystal or, if addback is enabled, in the same detector
+               if(firstDet == secondDet && (firstCry == secondCry || addback)) continue;
+               double angle = TGriffin::GetPosition(firstDet, firstCry, distance).Angle(TGriffin::GetPosition(secondDet, secondCry, distance)) *180./TMath::Pi();
+               // if folding is enable we fold the distribution at 90 degree and only use angles between 0 and 90 degree
+               if(folding && angle > 90.) {
+                  angle = 180. - angle;
+               }
+               fAngles.insert(angle);
+            }
+         }
+      }
+   }
+
+	// create map of indices before we group so that we have an index for each (folded) angle
+	for(auto it = fAngles.begin(); it != fAngles.end(); ++it) {
+		fAngleMap.insert(std::make_pair(*it, std::distance(fAngles.begin(), it)));
+	}
+
+   if(grouping) {
+      // If grouping is enable we group angles that are close to each other together.
+      // Which angles are grouped is somewhat arbitrary, this grouping was chosen to get similar numbers of detector combinations and thus statistics for each angle group.
+      // Due to the way lower_bound works, we use the highest angle of each group as the angle of that group.
+      // This is just for the purpose of this algorithm, when plotting the correct average angle of the group should be used!
+		std::set<double, std::function<bool(const double&, const double&)>> groupedAngles([this](const double& lhs, const double& rhs) { return std::abs(lhs-rhs) < fRounding; });
+		// for the angle map we need to update the indices: 3->2, 4->3, 5->3, 6->4, 7->4, 8->5, 9->5, 10->5, 11->6, 12->6, 13->6 and so on
+      for(auto it = fAngles.begin(); it != fAngles.end(); ++it) {
+			auto i = std::distance(fAngles.begin(), it);
+         switch(i) {
+         case 0:
+         case 1:
+            // first and second angle are not grouped
+            groupedAngles.insert(*it);
+            break;
+         case 2:
+         case 4:
+         case 6:
+            // three groups of two angles each
+				// 2->2, 4->3, 6->4
+				fAngleMap[*it] -= (i-2)/2;
+            ++it;
+				// 3->2, 5->3, 7->4
+				fAngleMap[*it] -= (i-2)/2+1;
+            groupedAngles.insert(*it);
+            break;
+         default:
+            // all others are groups of three
+				//  8->5, 11->6, 14->7, ...
+				fAngleMap[*it] -= (i-5)/3*2+1;
+            ++it;
+				//  9->5, 12->6, 15->7, ...
+				fAngleMap[*it] -= (i-2)/3*2+2;
+            ++it;
+				// 10->5, 13->6, 16->7, ...
+				fAngleMap[*it] -= (i-2)/3*2+2;
+            groupedAngles.insert(*it);
+            break;
+         }
+      }
+      fAngles = groupedAngles;
+   }
+}
+
+int TGriffinAngles::Index(double angle)
+{
+	auto matches = [angle, this](std::pair<double, int> val) { return std::abs(val.first-angle) < fRounding; };
+	auto it = std::find_if(fAngleMap.begin(), fAngleMap.end(), matches);
+
+	return (it != fAngleMap.end()) ? it->second : -1;
+}
+
+void TGriffinAngles::Print() const
+{
+	std::cout<<"List of unique angles:"<<std::endl;
+	for(auto it = fAngles.begin(); it != fAngles.end(); ++it) {
+		std::cout<<std::distance(fAngles.begin(), it)<<": "<<*it<<std::endl;//<<" - index "<<Index(*it)<<std::endl;
+	}
+	std::cout<<"Map from angles to indices:"<<std::endl;
+	for(auto const& it : fAngleMap) {
+		std::cout<<"angle "<<it.first<<", index "<<it.second<<std::endl;
+	}
+}

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffinAngles.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffinAngles.cxx
@@ -4,21 +4,24 @@
 ClassImp(TGriffinAngles)
 
 TGriffinAngles::TGriffinAngles(double distance, bool folding, bool grouping, bool addback)
-	: fAngles([this](const double& lhs, const double& rhs) { return std::abs(lhs-rhs) < fRounding; })
+	: fDistance(distance), fFolding(folding), fGrouping(grouping), fAddback(addback)
 {
+	SetName("GriffinAngles");
    // loop over all possible detector/crystal combinations
    for(int firstDet = 1; firstDet <= 16; ++firstDet) {
       for(int firstCry = 0; firstCry < 4; ++firstCry) {
          for(int secondDet = 1; secondDet <= 16; ++secondDet) {
             for(int secondCry = 0; secondCry < 4; ++secondCry) {
                // exclude hits in the same crystal or, if addback is enabled, in the same detector
-               if(firstDet == secondDet && (firstCry == secondCry || addback)) continue;
-               double angle = TGriffin::GetPosition(firstDet, firstCry, distance).Angle(TGriffin::GetPosition(secondDet, secondCry, distance)) *180./TMath::Pi();
+               if(firstDet == secondDet && (firstCry == secondCry || fAddback)) continue;
+               double angle = TGriffin::GetPosition(firstDet, firstCry, fDistance).Angle(TGriffin::GetPosition(secondDet, secondCry, fDistance)) *180./TMath::Pi();
                // if folding is enable we fold the distribution at 90 degree and only use angles between 0 and 90 degree
-               if(folding && angle > 90.) {
+               if(fFolding && angle > 90.) {
                   angle = 180. - angle;
                }
-               fAngles.insert(angle);
+               if(fAngles.lower_bound(angle-fRounding) == fAngles.upper_bound(angle+fRounding)) {
+						fAngles.insert(angle);
+					}
             }
          }
       }
@@ -29,12 +32,12 @@ TGriffinAngles::TGriffinAngles(double distance, bool folding, bool grouping, boo
 		fAngleMap.insert(std::make_pair(*it, std::distance(fAngles.begin(), it)));
 	}
 
-   if(grouping) {
+   if(fGrouping) {
       // If grouping is enable we group angles that are close to each other together.
       // Which angles are grouped is somewhat arbitrary, this grouping was chosen to get similar numbers of detector combinations and thus statistics for each angle group.
       // Due to the way lower_bound works, we use the highest angle of each group as the angle of that group.
       // This is just for the purpose of this algorithm, when plotting the correct average angle of the group should be used!
-		std::set<double, std::function<bool(const double&, const double&)>> groupedAngles([this](const double& lhs, const double& rhs) { return std::abs(lhs-rhs) < fRounding; });
+		std::set<double> groupedAngles;
 		// for the angle map we need to update the indices: 3->2, 4->3, 5->3, 6->4, 7->4, 8->5, 9->5, 10->5, 11->6, 12->6, 13->6 and so on
       for(auto it = fAngles.begin(); it != fAngles.end(); ++it) {
 			auto i = std::distance(fAngles.begin(), it);
@@ -61,10 +64,10 @@ TGriffinAngles::TGriffinAngles(double distance, bool folding, bool grouping, boo
 				fAngleMap[*it] -= (i-5)/3*2+1;
             ++it;
 				//  9->5, 12->6, 15->7, ...
-				fAngleMap[*it] -= (i-2)/3*2+2;
+				fAngleMap[*it] -= (i-5)/3*2+2;
             ++it;
 				// 10->5, 13->6, 16->7, ...
-				fAngleMap[*it] -= (i-2)/3*2+2;
+				fAngleMap[*it] -= (i-5)/3*2+3;
             groupedAngles.insert(*it);
             break;
          }
@@ -78,17 +81,40 @@ int TGriffinAngles::Index(double angle)
 	auto matches = [angle, this](std::pair<double, int> val) { return std::abs(val.first-angle) < fRounding; };
 	auto it = std::find_if(fAngleMap.begin(), fAngleMap.end(), matches);
 
-	return (it != fAngleMap.end()) ? it->second : -1;
+	if(it == fAngleMap.end()) {
+		std::cout<<"Failed to find angle "<<angle<<" in map!"<<std::endl;
+		return -1;
+	}
+	if(it->second >= static_cast<int>(fAngles.size())) {
+		std::cout<<"Found index "<<it->second<<" for angle "<<angle<<" which is outside range ("<<fAngles.size()<<")"<<std::endl;
+		return -1;
+	}
+	return it->second;
 }
 
-void TGriffinAngles::Print() const
+double TGriffinAngles::AverageAngle(int index) const
+{
+	double result = 0.;
+	int nofMatches = 0;
+	for(const auto& val : fAngleMap) {
+		if(val.second == index) {
+			result += val.first;
+			++nofMatches;
+		}
+	}
+	return result/nofMatches;
+}
+
+void TGriffinAngles::Print(Option_t*) const
 {
 	std::cout<<"List of unique angles:"<<std::endl;
 	for(auto it = fAngles.begin(); it != fAngles.end(); ++it) {
 		std::cout<<std::distance(fAngles.begin(), it)<<": "<<*it<<std::endl;//<<" - index "<<Index(*it)<<std::endl;
 	}
 	std::cout<<"Map from angles to indices:"<<std::endl;
+	int i = 0;
 	for(auto const& it : fAngleMap) {
-		std::cout<<"angle "<<it.first<<", index "<<it.second<<std::endl;
+		std::cout<<i<<": angle "<<it.first<<", index "<<it.second<<" - average angle "<<AverageAngle(it.second)<<std::endl;
+		++i;
 	}
 }

--- a/libraries/TMidas/TMidasEvent.cxx
+++ b/libraries/TMidas/TMidasEvent.cxx
@@ -295,7 +295,7 @@ void TMidasEvent::Print(const char* option) const
          void* pdata      = nullptr;
          int   found      = FindBank(&fBankList[i], &bankLength, &bankType, &pdata);
 
-			std::cout<<"Bank "<<fBankList[i]<<fBankList[i+1]<<fBankList[i+2]<<", length "<<std::setw(6)<<bankLength<<", type "<<bankType<<std::endl;
+			std::cout<<"Bank "<<fBankList[i]<<fBankList[i+1]<<fBankList[i+2]<<fBankList[i+3]<<", length "<<std::setw(6)<<bankLength<<", type "<<bankType<<std::endl;
 
          int highlight = -1;
          if(strlen(option) > 1) {

--- a/util/AngularCorrelations.cxx
+++ b/util/AngularCorrelations.cxx
@@ -1,0 +1,172 @@
+#include "TFile.h"
+#include "TH2.h"
+#include "TH1.h"
+#include "TGraphErrors.h"
+
+#include "ArgParser.h"
+#include "TGriffinAngles.h"
+#include "TPeakFitter.h"
+#include "TRWPeak.h"
+
+/// program to read in 2D matrices from AngularCorrelationHelper
+/// project and fit peaks to create angular correlation plots
+/// and to create chi-square plots
+int main(int argc, char** argv)
+{
+	// input parameters
+	bool help = false;
+	double projGateLow = 0.;
+	double projGateHigh = -1;
+	double projBgLow = 0.;
+	double projBgHigh = -1.;
+	double timeRandomNorm = -1.;
+	std::string baseName = "AngularCorrelation";
+	double peakPos = 0.;
+	double peakLow = 0.;
+	double peakHigh = -1.;
+	std::string inputFile;
+
+	ArgParser parser;
+	parser.option("h help ?", &help, true).description("Show this help message.");
+	parser.option("projection-low proj-low", &projGateLow, true).description("Low edge of projection gate.");
+	parser.option("projection-high proj-high", &projGateHigh, true).description("High edge of projection gate.");
+	parser.option("background-low bg-low", &projBgLow, true).description("Low edge of background gate.");
+	parser.option("background-high bg-high", &projBgHigh, true).description("High edge of background gate.");
+	parser.option("time-random-normalization", &timeRandomNorm, true).description("Normalization factor for subtraction of time-random matrix. If negative (default) it will be calculated automatically.");
+	parser.option("base-name", &baseName, true).description("Base name of matrices.").default_value("AngularCorrelation");
+	parser.option("peak-pos peak", &peakPos, true).description("Peak position.");
+	parser.option("peak-low", &peakLow, true).description("Low edge of peak fit.");
+	parser.option("peak-high", &peakHigh, true).description("High edge of peak fit.");
+	parser.option("input", &inputFile, true).description("Input file with gamma-gamma matrices for each angle (coincident, time-random, and event mixed).");
+
+	parser.parse(argc, argv, true);
+
+	if(help) {
+		std::cout<<parser<<std::endl;
+		return 1;
+	}
+
+	// check if all necessary settings have been provided
+	if(projGateLow >= projGateHigh) {
+		std::cerr<<"Need a projection gate with a low edge that is smaller than the high edge, "<<projGateLow<<" >= "<<projGateHigh<<std::endl;
+		return 1;
+	}
+
+	if(projBgLow >= projBgHigh) {
+		std::cerr<<"Need a background gate with a low edge that is smaller than the high edge, "<<projBgLow<<" >= "<<projBgHigh<<std::endl;
+		return 1;
+	}
+
+	if(peakLow >= peakHigh) {
+		std::cerr<<"Need a fit range with a low edge that is smaller than the high edge, "<<peakLow<<" >= "<<peakHigh<<std::endl;
+		return 1;
+	}
+
+	if(peakPos >= peakHigh || peakPos <= peakLow) {
+		std::cerr<<"Need a peak within the fit range, "<<peakPos<<" not within "<<peakLow<<" - "<<peakHigh<<std::endl;
+		return 1;
+	}
+
+	if(timeRandomNorm <= 0.) {
+		std::cerr<<"Need a positive normalization factor for time random subtraction"<<std::endl;
+		return 1;
+	}
+
+	if(inputFile.empty()) {
+		std::cerr<<"Need an input file!"<<std::endl;
+		return 1;
+	}
+
+	TFile input(inputFile.c_str());
+
+	if(!input.IsOpen()) {
+		std::cerr<<"Failed to open input file "<<inputFile<<std::endl;
+		return 1;
+	}
+
+	auto angles = static_cast<TGriffinAngles*>(input.Get("GriffinAngles"));
+
+	if(angles == nullptr) {
+		std::cerr<<"Failed to find 'GriffinAngles' in '"<<inputFile<<"'"<<std::endl;
+		return 1;
+	}
+
+	// open output file and create graphs
+	// TODO: base the output file name off the input files name? i.e. take the run number(s) and subrun number(s) from the input string
+	TFile output("AngularCorrelations.root", "recreate");
+
+	auto rawAngularDistribution = new TGraphErrors(angles->NumberOfAngles());
+	rawAngularDistribution->SetName("RawAngularDistribution");
+	auto angularDistribution = new TGraphErrors(angles->NumberOfAngles());
+	angularDistribution->SetName("AngularDistribution");
+	auto mixedAngularDistribution = new TGraphErrors(angles->NumberOfAngles());
+	mixedAngularDistribution->SetName("MixedAngularDistribution");
+
+	// loop over all matrices
+	for(int i = 0; i < angles->NumberOfAngles(); ++i) {
+		// get the three histograms we need: prompt, time random, and event mixed
+		auto prompt = static_cast<TH2*>(input.Get(Form("AngularCorrelation%d", i)));
+		if(prompt == nullptr) {
+			std::cerr<<"Failed to find histogram '"<<Form("AngularCorrelation%d", i)<<"', should have "<<angles->NumberOfAngles()<<" angles in total!"<<std::endl;
+			return 1;
+		}
+		auto bg = static_cast<TH2*>(input.Get(Form("AngularCorrelationBG%d", i)));
+		if(bg == nullptr) {
+			std::cerr<<"Failed to find histogram '"<<Form("AngularCorrelationBG%d", i)<<"', should have "<<angles->NumberOfAngles()<<" angles in total!"<<std::endl;
+			return 1;
+		}
+		auto mixed = static_cast<TH2*>(input.Get(Form("AngularCorrelationMixed%d", i)));
+		if(mixed == nullptr) {
+			std::cerr<<"Failed to find histogram '"<<Form("AngularCorrelationMixed%d", i)<<"', should have "<<angles->NumberOfAngles()<<" angles in total!"<<std::endl;
+			return 1;
+		}
+		
+		// first subtract time random background from prompt data and enable proper error propagation for prompt and mixed data
+		prompt->Sumw2();
+		prompt->Add(bg, -timeRandomNorm);
+		mixed->Sumw2();
+
+		// TODO: multiple background gates and peaks?
+		// project onto x-axis
+		auto proj = prompt->ProjectionX(Form("proj%d",i), prompt->GetYaxis()->FindBin(projGateLow), prompt->GetYaxis()->FindBin(projGateHigh));
+		auto projMixed = mixed->ProjectionX(Form("projMixed%d",i), mixed->GetYaxis()->FindBin(projGateLow), mixed->GetYaxis()->FindBin(projGateHigh));
+		// project background gate onto x-axis
+		auto projBg = prompt->ProjectionX(Form("projBg%d",i), prompt->GetYaxis()->FindBin(projBgLow), prompt->GetYaxis()->FindBin(projBgHigh));
+		auto projMixedBg = mixed->ProjectionX(Form("projMixedBg%d",i), mixed->GetYaxis()->FindBin(projBgLow), mixed->GetYaxis()->FindBin(projBgHigh));
+		// subtract background gate (+1 because the projection includes first and last bin)
+		proj->Add(projBg, -(prompt->GetYaxis()->FindBin(projGateHigh)-prompt->GetYaxis()->FindBin(projGateLow)+1)/(prompt->GetYaxis()->FindBin(projBgHigh)-prompt->GetYaxis()->FindBin(projBgLow)+1));
+		projMixed->Add(projMixedBg, -(mixed->GetYaxis()->FindBin(projGateHigh)-mixed->GetYaxis()->FindBin(projGateLow)+1)/(mixed->GetYaxis()->FindBin(projBgHigh)-mixed->GetYaxis()->FindBin(projBgLow)+1));
+
+		// fit the projections, we create separate peak fitters and peaks for the prompt and mixed histograms
+		TPeakFitter pf(peakLow, peakHigh);
+		TRWPeak peak(peakPos);
+		pf.AddPeak(&peak);
+		pf.Fit(proj);
+
+		TPeakFitter pfMixed(peakLow, peakHigh);
+		TRWPeak peakMixed(peakPos);
+		pfMixed.AddPeak(&peakMixed);
+		pfMixed.Fit(projMixed);
+
+		// save the fitted histograms to the output file and the areas of the peaks
+		proj->Write();
+		projMixed->Write();
+
+		// TODO: set an error for the angles?
+		rawAngularDistribution->SetPoint(i, angles->AverageAngle(i), peak.Area());
+		rawAngularDistribution->SetPointError(i, 0., peak.AreaErr());
+		mixedAngularDistribution->SetPoint(i, angles->AverageAngle(i), peakMixed.Area());
+		mixedAngularDistribution->SetPointError(i, 0., peakMixed.AreaErr());
+		angularDistribution->SetPoint(i, angles->AverageAngle(i), peak.Area()/peakMixed.Area());
+		angularDistribution->SetPointError(i, 0., peak.Area()/peakMixed.Area() * TMath::Sqrt(TMath::Power(peak.AreaErr()/peak.Area(), 2) + TMath::Power(peakMixed.AreaErr()/peakMixed.Area(), 2)));
+	}
+
+	rawAngularDistribution->Write();
+	angularDistribution->Write();
+	mixedAngularDistribution->Write();
+	
+	output.Close();
+	input.Close();
+
+	return 0;
+}


### PR DESCRIPTION
The new TGriffinAngles class calculates all angles for a given distance, and whether folding, grouping, and/or addback are used. One thing missing would be an easy way to exclude specific detectors or crystals. This class is needed for GRIFFINCollaboration/GRSISort#1380.
The AngularCorrelations program takes the output created by the reworked helper (see GRIFFINCollaboration/GRSISort#1380) and, based on command line flags, projects the matrices for each angle onto the x-axis and fit the peaks. The areas of the time-random corrected prompt matrices and the mixed matrices are divided by each other and stored in a TGraphErrors. The projections (with the fits) are stored in an output root-file along with the graphs of the uncorrected areas, the mixed areas, and the corrected areas. Things to add are the option to use settings files to provide the projection gates, peaks to fit, etc. (this includes the option to have multiple background gate to subtract), and an option to fix and/or limit specific fit parameters.