### PR TITLE
Updated and added functionality for AngularCorrelations program 

### DIFF
--- a/include/TGriffinAngles.h
+++ b/include/TGriffinAngles.h
@@ -20,6 +20,7 @@
 #include <functional>
 
 #include "TNamed.h"
+#include "TGraphErrors.h"
 
 class TGriffinAngles : public TNamed {
 public:
@@ -27,17 +28,21 @@ public:
 	~TGriffinAngles() {}
 
 	double Distance() { return fDistance; }
-	double Folding() { return fFolding; }
-	double Grouping() { return fGrouping; }
-	double Addback() { return fAddback; }
+	bool Folding() { return fFolding; }
+	bool Grouping() { return fGrouping; }
+	bool Addback() { return fAddback; }
 
 	int Index(double angle);
 	int NumberOfAngles() const { return fAngles.size(); }
 	double Angle(int index) const { auto it = fAngles.begin(); std::advance(it, index); return *it; }
 	double AverageAngle(int index) const;
 
+	void FoldOrGroup(TGraphErrors* z0, TGraphErrors* z2, TGraphErrors* z4, bool verbose = false) const;
 	std::set<double>::iterator begin() const { return fAngles.begin(); }
 	std::set<double>::iterator end() const { return fAngles.end(); }
+
+	bool ExcludeDetector(int detector) const;
+	bool ExcludeCrystal(int detector, int crystal) const;
 
 	void Print(Option_t* = "") const override;
 
@@ -47,11 +52,13 @@ private:
 	bool fGrouping{false}; ///< flag indicating whether we group close angles together
 	bool fAddback{true}; ///< flag indicating whether we use addback
 	double fRounding{0.01}; ///< we consider any angles whose difference is less than this to be equal
+	std::vector<int> fExcludedDetectors; ///< list of detectors that are excluded in calculating the angles
+	std::vector<int> fExcludedCrystals; ///< list of crystals that are excluded in calculating the angles, the crystals are numbered as 4*(det-1)+cry, so start at 0 and go up to 63
 	std::set<double> fAngles; ///< set of unique angles, when grouping is used, the largest angle of the group is used!
 	std::map<double, int> fAngleMap; ///< Maps angles to indices. This is fairly straight forward without grouping, but if grouping is used multiple angles can be mapped to the same index.
 
 	/// \cond CLASSIMP
-	ClassDefOverride(TGriffinAngles, 2)
+	ClassDefOverride(TGriffinAngles, 3)
 	/// \endcond
 };
 /*! @} */

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffinAngles.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffinAngles.cxx
@@ -11,8 +11,8 @@ TGriffinAngles::TGriffinAngles(double distance, bool folding, bool grouping, boo
 	if(TGRSIOptions::Get() != nullptr) {
 		auto settings = TGRSIOptions::Get()->UserSettings();
 		if(settings != nullptr) {
-			fExcludedCrystals = settings->GetIntVector("ExcludedCrystals");
-			fExcludedDetectors = settings->GetIntVector("ExcludedDetectors");
+			fExcludedCrystals = settings->GetIntVector("ExcludedCrystal");
+			fExcludedDetectors = settings->GetIntVector("ExcludedDetector");
 		} else {
 			std::cout<<"Failed to find user settings in TGRSIOptions, can't get user settings for excluded detectors/crystals"<<std::endl;
 		}

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffinAngles.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffinAngles.cxx
@@ -7,11 +7,28 @@ TGriffinAngles::TGriffinAngles(double distance, bool folding, bool grouping, boo
 	: fDistance(distance), fFolding(folding), fGrouping(grouping), fAddback(addback)
 {
 	SetName("GriffinAngles");
+	// get user settings for excluded detectors/crystals
+	if(TGRSIOptions::Get() != nullptr) {
+		auto settings = TGRSIOptions::Get()->UserSettings();
+		if(settings != nullptr) {
+			fExcludedCrystals = settings->GetIntVector("ExcludedCrystals");
+			fExcludedDetectors = settings->GetIntVector("ExcludedDetectors");
+		} else {
+			std::cout<<"Failed to find user settings in TGRSIOptions, can't get user settings for excluded detectors/crystals"<<std::endl;
+		}
+	} else {
+		std::cout<<"Failed to find TGRSIOptions, can't get user settings for excluded detectors/crystals"<<std::endl;
+	}
+	
    // loop over all possible detector/crystal combinations
    for(int firstDet = 1; firstDet <= 16; ++firstDet) {
+		if(ExcludeDetector(firstDet)) continue;
       for(int firstCry = 0; firstCry < 4; ++firstCry) {
+			if(ExcludeCrystal(firstDet, firstCry)) continue;
          for(int secondDet = 1; secondDet <= 16; ++secondDet) {
+				if(ExcludeDetector(secondDet)) continue;
             for(int secondCry = 0; secondCry < 4; ++secondCry) {
+					if(ExcludeCrystal(secondDet, secondCry)) continue;
                // exclude hits in the same crystal or, if addback is enabled, in the same detector
                if(firstDet == secondDet && (firstCry == secondCry || fAddback)) continue;
                double angle = TGriffin::GetPosition(firstDet, firstCry, fDistance).Angle(TGriffin::GetPosition(secondDet, secondCry, fDistance)) *180./TMath::Pi();
@@ -103,6 +120,172 @@ double TGriffinAngles::AverageAngle(int index) const
 		}
 	}
 	return result/nofMatches;
+}
+
+void TGriffinAngles::FoldOrGroup(TGraphErrors* z0, TGraphErrors* z2, TGraphErrors* z4, bool verbose) const 
+{
+	/// Apply folding and/or grouping to the theory graphs.
+	/// This assumes that the theory graphs all have the exact same length of 49 or 51 for singles or addback, respectively.
+
+	// these are simulated data, so if we add points together we take their average as the new value and change the uncertainties accordingly
+	if(verbose) {
+		std::cout<<"-------------------- original --------------------"<<std::endl;
+		for(int i = 0; i < z0->GetN(); ++i) {
+			std::cout<<std::setw(8)<<z0->GetPointX(i)<<": "<<std::setw(8)<<z0->GetPointY(i)<<" "<<std::setw(8)<<z2->GetPointY(i)<<" "<<std::setw(8)<<z4->GetPointY(i)<<std::endl;
+		}
+		std::cout<<"--------------------------------------------------"<<std::endl;
+	}
+
+	// folding first
+	if(fFolding) {
+		// we first change the angles of the data points, then we re-sort the graphs, and finally we combine points for the same angle into one
+		auto angle0 = z0->GetX();
+		auto angle2 = z2->GetX();
+		auto angle4 = z4->GetX();
+		for(int i = 0; i < z0->GetN(); ++i) {
+			if(angle0[i] > 90.) {
+				if(verbose) {
+					std::cout<<i<<": Folding from "<<std::setw(8)<<z0->GetPointX(i)<<" "<<std::setw(8)<<z2->GetPointX(i)<<" "<<std::setw(8)<<z4->GetPointX(i);
+				}
+				angle0[i] = 180. - angle0[i];
+				angle2[i] = angle0[i];
+				angle4[i] = angle0[i];
+				if(verbose) {
+					std::cout<<" to "<<std::setw(8)<<z0->GetPointX(i)<<" "<<std::setw(8)<<z2->GetPointX(i)<<" "<<std::setw(8)<<z4->GetPointX(i)<<std::endl;
+				}
+			}
+		}
+		z0->Sort();
+		z2->Sort();
+		z4->Sort();
+		if(verbose) {
+			std::cout<<"-------------------- sorted --------------------"<<std::endl;
+			for(int i = 0; i < z0->GetN(); ++i) {
+				std::cout<<std::setw(8)<<z0->GetPointX(i)<<": "<<std::setw(8)<<z0->GetPointY(i)<<" "<<std::setw(8)<<z2->GetPointY(i)<<" "<<std::setw(8)<<z4->GetPointY(i)<<std::endl;
+			}
+			std::cout<<"------------------------------------------------"<<std::endl;
+		}
+		angle0 = z0->GetX();
+		auto counts0 = z0->GetY(); auto errors0 = z0->GetEY();
+		auto counts2 = z2->GetY(); auto errors2 = z2->GetEY();
+		auto counts4 = z4->GetY(); auto errors4 = z4->GetEY();
+		for(int i = 1; i < z0->GetN(); ++i) {
+			if(std::abs(angle0[i] - angle0[i-1]) < fRounding) {
+				if(verbose) {
+					std::cout<<i<<": Adding angles "<<angle0[i-1]<<" and "<<angle0[i]<<std::endl;
+				}
+				// add counts from this point to the previous point, then delete this point, and update our pointers to the data
+				counts0[i-1] += counts0[i]; counts0[i-1] /= 2.; errors0[i-1] = TMath::Sqrt(TMath::Power(errors0[i-1], 2) + TMath::Power(errors0[i], 2))/2.;
+				counts2[i-1] += counts2[i]; counts2[i-1] /= 2.; errors2[i-1] = TMath::Sqrt(TMath::Power(errors2[i-1], 2) + TMath::Power(errors2[i], 2))/2.;
+				counts4[i-1] += counts4[i]; counts4[i-1] /= 2.; errors4[i-1] = TMath::Sqrt(TMath::Power(errors4[i-1], 2) + TMath::Power(errors4[i], 2))/2.;
+				z0->RemovePoint(i);
+				z2->RemovePoint(i);
+				z4->RemovePoint(i);
+				angle0 = z0->GetX();
+				counts0 = z0->GetY(); errors0 = z0->GetEY();
+				counts2 = z2->GetY(); errors2 = z2->GetEY();
+				counts4 = z4->GetY(); errors4 = z4->GetEY();
+				--i; // decrement to re-check the new ith point
+			} else {
+				if(verbose) {
+					std::cout<<i<<": Not adding angles "<<angle0[i-1]<<" and "<<angle0[i]<<std::endl;
+				}
+			}
+		}
+	}
+	if(verbose) {
+		std::cout<<"-------------------- after folding --------------------"<<std::endl;
+		for(int i = 0; i < z0->GetN(); ++i) {
+			std::cout<<std::setw(8)<<z0->GetPointX(i)<<": "<<std::setw(8)<<z0->GetPointY(i)<<" "<<std::setw(8)<<z2->GetPointY(i)<<" "<<std::setw(8)<<z4->GetPointY(i)<<std::endl;
+		}
+		std::cout<<"-------------------------------------------------------"<<std::endl;
+	}
+
+	// grouping
+	if(fGrouping) {
+		// Due to the way lower_bound works, we use the highest angle of each group as the angle of that group.
+		// This is just for the purpose of this algorithm, when plotting the correct average angle of the group should be used!
+		auto counts0 = z0->GetY(); auto errors0 = z0->GetEY();
+		auto counts2 = z2->GetY(); auto errors2 = z2->GetEY();
+		auto counts4 = z4->GetY(); auto errors4 = z4->GetEY();
+		for(int i = 0; i < z0->GetN(); ++i) {
+			switch(i) {
+				case 0:
+				case 1: // first and second angle are not grouped
+					if(verbose) {
+						std::cout<<i<<": Leaving as is "<<z0->GetPointX(i)<<": "<<std::setw(8)<<z0->GetPointY(i)<<" "<<std::setw(8)<<z2->GetPointY(i)<<" "<<std::setw(8)<<z4->GetPointY(i)<<std::endl;
+					}
+					break;
+				case 2:
+				case 3:
+				case 4:
+					// three groups of two angles each, so we add the this point to the next one, delete it, and update the pointers
+					// because we delete the point, we don't skip cases here like when we create the angles above
+					if(verbose) {
+						std::cout<<i<<": Grouping "<<z0->GetPointX(i)<<" and "<<z0->GetPointX(i+1)<<" from "<<std::setw(8)<<z0->GetPointY(i)<<" "<<std::setw(8)<<z2->GetPointY(i)<<" "<<std::setw(8)<<z4->GetPointY(i);
+					}
+					counts0[i+1] += counts0[i]; counts0[i+1] /= 2.; errors0[i+1] = TMath::Sqrt(TMath::Power(errors0[i], 2) + TMath::Power(errors0[i+1], 2))/2.;
+					counts2[i+1] += counts2[i]; counts2[i+1] /= 2.; errors2[i+1] = TMath::Sqrt(TMath::Power(errors2[i], 2) + TMath::Power(errors2[i+1], 2))/2.;
+					counts4[i+1] += counts4[i]; counts4[i+1] /= 2.; errors4[i+1] = TMath::Sqrt(TMath::Power(errors4[i], 2) + TMath::Power(errors4[i+1], 2))/2.;
+					z0->RemovePoint(i);
+					z2->RemovePoint(i);
+					z4->RemovePoint(i);
+					counts0 = z0->GetY(); errors0 = z0->GetEY();
+					counts2 = z2->GetY(); errors2 = z2->GetEY();
+					counts4 = z4->GetY(); errors4 = z4->GetEY();
+					if(verbose) {
+						std::cout<<" to "<<z0->GetPointX(i)<<" with "<<std::setw(8)<<z0->GetPointY(i)<<" "<<std::setw(8)<<z2->GetPointY(i)<<" "<<std::setw(8)<<z4->GetPointY(i)<<std::endl;
+					}
+					// no need to decrement the index, by removing one point the old i+1 became i and we don't want to process that one (we just added to it)
+					break;
+				default:
+					// all others are groups of three, so we add this point and the next one to the one two ahead, delete them, and update the pointers
+					if(verbose) {
+						std::cout<<i<<": Grouping "<<z0->GetPointX(i)<<", "<<z0->GetPointX(i+1)<<", and "<<z0->GetPointX(i+2)<<" from "<<std::setw(8)<<z0->GetPointY(i)<<" "<<std::setw(8)<<z2->GetPointY(i)<<" "<<std::setw(8)<<z4->GetPointY(i);
+					}
+					counts0[i+2] += counts0[i] + counts0[i+1]; counts0[i+2] /= 3.; errors0[i+2] = TMath::Sqrt(TMath::Power(errors0[i], 2) + TMath::Power(errors0[i+1], 2) + TMath::Power(errors0[i+2], 2))/3.;
+					counts2[i+2] += counts2[i] + counts2[i+1]; counts2[i+2] /= 3.; errors2[i+2] = TMath::Sqrt(TMath::Power(errors2[i], 2) + TMath::Power(errors2[i+1], 2) + TMath::Power(errors0[i+2], 2))/3.;
+					counts4[i+2] += counts4[i] + counts4[i+1]; counts4[i+2] /= 3.; errors4[i+2] = TMath::Sqrt(TMath::Power(errors4[i], 2) + TMath::Power(errors4[i+1], 2) + TMath::Power(errors0[i+2], 2))/3.;
+					z0->RemovePoint(i);
+					z2->RemovePoint(i);
+					z4->RemovePoint(i);
+					z0->RemovePoint(i+1);
+					z2->RemovePoint(i+1);
+					z4->RemovePoint(i+1);
+					counts0 = z0->GetY(); errors0 = z0->GetEY();
+					counts2 = z2->GetY(); errors2 = z2->GetEY();
+					counts4 = z4->GetY(); errors4 = z4->GetEY();
+					if(verbose) {
+						std::cout<<" to "<<z0->GetPointX(i)<<" with "<<std::setw(8)<<z0->GetPointY(i)<<" "<<std::setw(8)<<z2->GetPointY(i)<<" "<<std::setw(8)<<z4->GetPointY(i)<<std::endl;
+					}
+					// no need to decrement the index, by removing two points the old i+2 became i and we don't want to processs that one since we just added to it
+					break;
+			}
+		}
+	}
+	if(verbose) {
+		std::cout<<"-------------------- after folding and grouping --------------------"<<std::endl;
+		for(int i = 0; i < z0->GetN(); ++i) {
+			std::cout<<std::setw(8)<<z0->GetPointX(i)<<": "<<std::setw(8)<<z0->GetPointY(i)<<" "<<std::setw(8)<<z2->GetPointY(i)<<" "<<std::setw(8)<<z4->GetPointY(i)<<std::endl;
+		}
+		std::cout<<"--------------------------------------------------------------------"<<std::endl;
+	}
+}
+
+bool TGriffinAngles::ExcludeDetector(int detector) const
+{
+	for(auto exclude : fExcludedDetectors) {
+		if(detector == exclude) return true;
+	}
+	return false;
+}
+
+bool TGriffinAngles::ExcludeCrystal(int detector, int crystal) const
+{
+	for(auto exclude : fExcludedCrystals) {
+		if(4*(detector-1)+crystal == exclude) return true;
+	}
+	return false;
 }
 
 void TGriffinAngles::Print(Option_t*) const

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffinAngles.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffinAngles.cxx
@@ -1,5 +1,6 @@
 #include "TGriffinAngles.h"
 #include "TGriffin.h"
+#include "TGRSIOptions.h"
 
 ClassImp(TGriffinAngles)
 
@@ -283,7 +284,7 @@ bool TGriffinAngles::ExcludeDetector(int detector) const
 bool TGriffinAngles::ExcludeCrystal(int detector, int crystal) const
 {
 	for(auto exclude : fExcludedCrystals) {
-		if(4*(detector-1)+crystal == exclude) return true;
+		if(4*(detector-1)+crystal+1 == exclude) return true;
 	}
 	return false;
 }


### PR DESCRIPTION
- Added option to set the spin of the low, middle, and high levels involved in the cascade via a settings file. If one of the three vectors has more than one entry, graphs for the reduced chi^2 vs mixing ratio will be plotted for each spin.
- Added option to limit or fix the parameters for the peaks, background peaks, and the background. By default the high limit is lower than the low limit, meaning no limits are set. If both limits are the same, the parameter will be fixed to that value.
- The confidence level (represented by a horizontal line in the plot of reduced chi^2s vs mixing ratios) can now also be set via a user setting.
- The user settings are also written to the output file, to enable determining specific conditions based on the output file alone.

This also included some changes in TGriffinAngles:
- Using the "ExcludeDetector" or "ExcludeCrystal" settings the user can provide a list of detectors (integers 1-16), or crystals (integers 1-64) that are to be excluded in the calculation of the available angles.
- Also added a function to apply folding and/or grouping (if enabled) to provided simulated angular distributions z0, z2, and z4. This isn't the correct way to do it, but for a preliminary analysis it's close enough.
