### PR TITLE
Changes due to members in GRSISort being private instead of protected

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,214 @@
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -3
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveMacros: None
+AlignConsecutiveAssignments: Consecutive
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: Consecutive
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Always
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: AllIfsAndElse
+AllowShortLoopsOnASingleLine: true
+# This option is "deprecated and is retained for backwards compatibility."
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+#BreakAfterReturnType: Automatic
+#BreakArrays: false
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: true
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     0
+CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Left
+CompactNamespaces: false
+# ConstructorInitializerAllOnOneLineOrOnePerLine: false (deprecated)
+ConstructorInitializerIndentWidth: 3
+ContinuationIndentWidth: 3
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: BinPack
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowAllConstructorInitializersOnNextLine: true
+FixNamespaceComments: true
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IfMacros: [ KJ_IF_MAYBE ]
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^("|<)T'
+    Priority:        4
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^("|<)ROOT/'
+    Priority:        5
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        6
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseLabels: false
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequires:  false
+IndentWidth:     3
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+#InsertNewlineAtEOF: true
+#KeepEmptyLinesAtEOF: false
+KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: Signature
+#LineEnding: LF
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 3
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60000
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Left
+PPIndentWidth:   -1
+#QualifierOrder: [inline, static, type, const, volatile]
+ReferenceAlignment: Left
+ReflowComments:  false
+RemoveBracesLLVM: false
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    Never
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: Custom
+SpaceBeforeParensOptions:
+  AfterControlStatements: false
+  AfterForeachMacros: false
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   false
+  AfterOverloadedOperator: false
+  #AfterPlacementOperator: true
+  #AfterRequiresInClause: true
+  #AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 3
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         3
+SpacesInParentheses: false
+#SpacesInParens: Never
+SpacesInSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+  - ClassImp
+  - ClassDef
+  - ClassDefOverride
+  - NamespaceImp
+  - templateClassImp
+TabWidth:        3
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,357 @@
+---
+Checks:          'clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-alpha*,-*,modernize*,-modernize-use-trailing-return-type,cppcoreguidelines*,-cppcoreguidelines-avoid-non-const-global-variables,-cppcoreguidelines-owning-memory,-cppcoreguidelines-pro-type-vararg,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cppcoreguidelines-pro-type-static-cast-downcast,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-pro-type-member-init,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-pro-type-reinterpret-cast,google*,-google-readability-todo,-google-runtime-references,-google-default-arguments,misc-bool-pointer-implicit-conversion,misc-definitions-in-headers,misc-inefficient-algorithm,misc-string-*,performance*,readability*,-readability-named-parameter,-readability-magic-numbers,-readability-suspicious-call-argument,-readability-uppercase-literal-suffix,-readability-identifier-length,-readability-convert-member-functions-to-static'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+User:            vbildste
+CheckOptions:    
+  - key:             cert-oop11-cpp.UseCERTSemantics
+    value:           '1'
+  - key:             cppcoreguidelines-pro-bounds-constant-array-index.GslHeader
+    value:           ''
+  - key:             cppcoreguidelines-pro-bounds-constant-array-index.IncludeStyle
+    value:           'llvm'
+  - key:             cppcoreguidelines-pro-type-member-init.IgnoreArrays
+    value:           '0'
+  - key:             google-build-namespaces.HeaderFileExtensions
+    value:           h,hh,hpp,hxx
+  - key:             google-global-names-in-headers.HeaderFileExtensions
+    value:           h
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.BranchThreshold
+    value:           '4294967295'
+  - key:             google-readability-function-size.LineThreshold
+    value:           '4294967295'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             google-runtime-int.UnsignedTypePrefix
+    value:           uint
+  - key:             google-runtime-int.SignedTypePrefix
+    value:           int
+  - key:             google-runtime-int.TypeSuffix
+    value:           '_t'
+  - key:             misc-definitions-in-headers.HeaderFileExtensions
+    value:           ',h,hh,hpp,hxx'
+  - key:             misc-definitions-in-headers.UseHeaderFileExtension
+    value:           '1'
+  - key:             misc-string-constructor.LargeLengthThreshold
+    value:           '8388608'
+  - key:             misc-string-constructor.WarnOnLargeLength
+    value:           '1'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-auto.RemoveStars
+    value:           '0'
+  - key:             modernize-use-emplace.ContainersWithPushBack
+    value:           '::std::vector;::std::list;::std::deque'
+  - key:             modernize-use-emplace.SmartPointers
+    value:           '::std::shared_ptr;::std::unique_ptr;::std::auto_ptr;::std::weak_ptr'
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+  - key:					modernize-use-override.IgnoreDestructors
+    value:				true
+  - key:					cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
+    value:				true
+  - key:             performance-faster-string-find.StringLikeClasses
+    value:           'std::basic_string'
+  - key:             performance-for-range-copy.WarnOnAllAutoCopies
+    value:           '0'
+  - key:             performance-unnecessary-value-param.IncludeStyle
+    value:           llvm
+  - key:             readability-braces-around-statements.ShortStatementLines
+    value:           '0'
+  - key:             readability-function-size.BranchThreshold
+    value:           '4294967295'
+  - key:             readability-function-size.LineThreshold
+    value:           '4294967295'
+  - key:             readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             readability-identifier-length.MinimumVariableNameLength
+    value:           3
+  - key:             readability-identifier-length.MinimumParameterNameLength
+    value:           3
+  - key:             readability-identifier-naming.AbstractClassCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.AbstractClassPrefix
+    value:           ''
+  - key:             readability-identifier-naming.AbstractClassSuffix
+    value:           ''
+  - key:             readability-identifier-naming.ClassCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.ClassConstantCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.ClassConstantPrefix
+    value:           ''
+  - key:             readability-identifier-naming.ClassConstantSuffix
+    value:           ''
+  - key:             readability-identifier-naming.ClassMemberCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.ClassMemberPrefix
+    value:           'f'
+  - key:             readability-identifier-naming.ClassMemberSuffix
+    value:           ''
+  - key:             readability-identifier-naming.ClassMethodCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.ClassMethodPrefix
+    value:           ''
+  - key:             readability-identifier-naming.ClassMethodSuffix
+    value:           ''
+  - key:             readability-identifier-naming.ClassPrefix
+    value:           ''
+  - key:             readability-identifier-naming.ClassSuffix
+    value:           ''
+  - key:             readability-identifier-naming.ConstantCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.ConstantMemberCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.ConstantMemberPrefix
+    value:           ''
+  - key:             readability-identifier-naming.ConstantMemberSuffix
+    value:           ''
+  - key:             readability-identifier-naming.ConstantParameterCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.ConstantParameterPrefix
+    value:           ''
+  - key:             readability-identifier-naming.ConstantParameterSuffix
+    value:           ''
+  - key:             readability-identifier-naming.ConstantPrefix
+    value:           ''
+  - key:             readability-identifier-naming.ConstantSuffix
+    value:           ''
+  - key:             readability-identifier-naming.ConstexprFunctionCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.ConstexprFunctionPrefix
+    value:           ''
+  - key:             readability-identifier-naming.ConstexprFunctionSuffix
+    value:           ''
+  - key:             readability-identifier-naming.ConstexprMethodCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.ConstexprMethodPrefix
+    value:           ''
+  - key:             readability-identifier-naming.ConstexprMethodSuffix
+    value:           ''
+  - key:             readability-identifier-naming.ConstexprVariableCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.ConstexprVariablePrefix
+    value:           ''
+  - key:             readability-identifier-naming.ConstexprVariableSuffix
+    value:           ''
+  - key:             readability-identifier-naming.EnumCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.EnumConstantCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.EnumConstantPrefix
+    value:           ''
+  - key:             readability-identifier-naming.EnumConstantSuffix
+    value:           ''
+  - key:             readability-identifier-naming.EnumPrefix
+    value:           ''
+  - key:             readability-identifier-naming.EnumSuffix
+    value:           ''
+  - key:             readability-identifier-naming.FunctionCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.FunctionPrefix
+    value:           ''
+  - key:             readability-identifier-naming.FunctionSuffix
+    value:           ''
+  - key:             readability-identifier-naming.GlobalConstantCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.GlobalConstantPrefix
+    value:           ''
+  - key:             readability-identifier-naming.GlobalConstantSuffix
+    value:           ''
+  - key:             readability-identifier-naming.GlobalFunctionCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.GlobalFunctionPrefix
+    value:           ''
+  - key:             readability-identifier-naming.GlobalFunctionSuffix
+    value:           ''
+  - key:             readability-identifier-naming.GlobalVariableCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.GlobalVariablePrefix
+    value:           ''
+  - key:             readability-identifier-naming.GlobalVariableSuffix
+    value:           ''
+  - key:             readability-identifier-naming.IgnoreFailedSplit
+    value:           '0'
+  - key:             readability-identifier-naming.InlineNamespaceCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.InlineNamespacePrefix
+    value:           ''
+  - key:             readability-identifier-naming.InlineNamespaceSuffix
+    value:           ''
+  - key:             readability-identifier-naming.LocalConstantCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.LocalConstantPrefix
+    value:           ''
+  - key:             readability-identifier-naming.LocalConstantSuffix
+    value:           ''
+  - key:             readability-identifier-naming.LocalVariableCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.LocalVariablePrefix
+    value:           ''
+  - key:             readability-identifier-naming.LocalVariableSuffix
+    value:           ''
+  - key:             readability-identifier-naming.MacroDefinitionCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.MacroDefinitionPrefix
+    value:           ''
+  - key:             readability-identifier-naming.MacroDefinitionSuffix
+    value:           ''
+  - key:             readability-identifier-naming.MemberCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.MemberPrefix
+    value:           ''
+  - key:             readability-identifier-naming.MemberSuffix
+    value:           ''
+  - key:             readability-identifier-naming.MethodCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.MethodPrefix
+    value:           ''
+  - key:             readability-identifier-naming.MethodSuffix
+    value:           ''
+  - key:             readability-identifier-naming.NamespaceCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.NamespacePrefix
+    value:           ''
+  - key:             readability-identifier-naming.NamespaceSuffix
+    value:           ''
+  - key:             readability-identifier-naming.ParameterCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.ParameterPackCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.ParameterPackPrefix
+    value:           ''
+  - key:             readability-identifier-naming.ParameterPackSuffix
+    value:           ''
+  - key:             readability-identifier-naming.ParameterPrefix
+    value:           ''
+  - key:             readability-identifier-naming.ParameterSuffix
+    value:           ''
+  - key:             readability-identifier-naming.PrivateMemberCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.PrivateMemberPrefix
+    value:           ''
+  - key:             readability-identifier-naming.PrivateMemberSuffix
+    value:           ''
+  - key:             readability-identifier-naming.PrivateMethodCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.PrivateMethodPrefix
+    value:           ''
+  - key:             readability-identifier-naming.PrivateMethodSuffix
+    value:           ''
+  - key:             readability-identifier-naming.ProtectedMemberCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.ProtectedMemberPrefix
+    value:           ''
+  - key:             readability-identifier-naming.ProtectedMemberSuffix
+    value:           ''
+  - key:             readability-identifier-naming.ProtectedMethodCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.ProtectedMethodPrefix
+    value:           ''
+  - key:             readability-identifier-naming.ProtectedMethodSuffix
+    value:           ''
+  - key:             readability-identifier-naming.PublicMemberCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.PublicMemberPrefix
+    value:           ''
+  - key:             readability-identifier-naming.PublicMemberSuffix
+    value:           ''
+  - key:             readability-identifier-naming.PublicMethodCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.PublicMethodPrefix
+    value:           ''
+  - key:             readability-identifier-naming.PublicMethodSuffix
+    value:           ''
+  - key:             readability-identifier-naming.StaticConstantCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.StaticConstantPrefix
+    value:           ''
+  - key:             readability-identifier-naming.StaticConstantSuffix
+    value:           ''
+  - key:             readability-identifier-naming.StaticVariableCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.StaticVariablePrefix
+    value:           ''
+  - key:             readability-identifier-naming.StaticVariableSuffix
+    value:           ''
+  - key:             readability-identifier-naming.StructCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.StructPrefix
+    value:           ''
+  - key:             readability-identifier-naming.StructSuffix
+    value:           ''
+  - key:             readability-identifier-naming.TemplateParameterCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.TemplateParameterPrefix
+    value:           ''
+  - key:             readability-identifier-naming.TemplateParameterSuffix
+    value:           ''
+  - key:             readability-identifier-naming.TemplateTemplateParameterCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.TemplateTemplateParameterPrefix
+    value:           ''
+  - key:             readability-identifier-naming.TemplateTemplateParameterSuffix
+    value:           ''
+  - key:             readability-identifier-naming.TypeAliasCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.TypeAliasPrefix
+    value:           ''
+  - key:             readability-identifier-naming.TypeAliasSuffix
+    value:           ''
+  - key:             readability-identifier-naming.TypeTemplateParameterCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.TypeTemplateParameterPrefix
+    value:           ''
+  - key:             readability-identifier-naming.TypeTemplateParameterSuffix
+    value:           ''
+  - key:             readability-identifier-naming.TypedefCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.TypedefPrefix
+    value:           ''
+  - key:             readability-identifier-naming.TypedefSuffix
+    value:           ''
+  - key:             readability-identifier-naming.UnionCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.UnionPrefix
+    value:           ''
+  - key:             readability-identifier-naming.UnionSuffix
+    value:           ''
+  - key:             readability-identifier-naming.ValueTemplateParameterCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.ValueTemplateParameterPrefix
+    value:           ''
+  - key:             readability-identifier-naming.ValueTemplateParameterSuffix
+    value:           ''
+  - key:             readability-identifier-naming.VariableCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.VariablePrefix
+    value:           ''
+  - key:             readability-identifier-naming.VariableSuffix
+    value:           ''
+  - key:             readability-identifier-naming.VirtualMethodCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.VirtualMethodPrefix
+    value:           ''
+  - key:             readability-identifier-naming.VirtualMethodSuffix
+    value:           ''
+  - key:             readability-simplify-boolean-expr.ChainedConditionalAssignment
+    value:           '0'
+  - key:             readability-simplify-boolean-expr.ChainedConditionalReturn
+    value:           '0'
+...
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,3 +254,9 @@ add_custom_target(GRSIDataVersion
                     -P ${CMAKE_SOURCE_DIR}/GenerateVersionHeader.cmake
   )
 
+#----------------------------------------------------------------------------
+# create a compile_commands.json file which can be used for clang-tidy
+if(NOT DEFINED ENV{CMAKE_EXPORT_COMPILE_COMMANDS})
+    message("ENV(CMAKE_EXPORT_COMPILE_COMMANDS) NOT DEFINED")
+    set($ENV{CMAKE_EXPORT_COMPILE_COMMANDS} TRUE)
+endif()

--- a/include/TGriffin.h
+++ b/include/TGriffin.h
@@ -44,7 +44,7 @@ public:
    TGriffinHit* GetGriffinHit(const int& i) { return GetGriffinHit(i, GetDefaultGainType()); } //!<!
    using TDetector::GetHit;
    TDetectorHit* GetHit(const int& idx);
-   Short_t GetLowGainMultiplicity() const { return fGriffinLowGainHits.size(); }
+   Short_t GetLowGainMultiplicity() const { return TDetector::GetMultiplicity(); }
    Short_t GetHighGainMultiplicity() const { return fGriffinHighGainHits.size(); }
    Short_t GetMultiplicity() const override { return GetMultiplicity(GetDefaultGainType()); }
 
@@ -133,7 +133,6 @@ private:
    static std::function<bool(const TDetectorHit*, const TDetectorHit*)> fSuppressionCriterion;
 #endif
 
-	std::vector<TDetectorHit*>& fGriffinLowGainHits = fHits; //!<! Reference to default hit vector (needs to be transient)
    std::vector<TDetectorHit*>  fGriffinHighGainHits; //  The set of crystal hits
 
    // static bool fSetBGOHits;                //!<!  Flag that determines if BGOHits are being measured

--- a/include/TMidasFile.h
+++ b/include/TMidasFile.h
@@ -58,7 +58,6 @@ public:
    bool WriteBuffer();
    // int GetBufferSize() const { return fWriteBuffer.size(); }
 
-   const char* GetFilename() const override { return fFilename.c_str(); } ///< Get the name of this file
    int         GetLastErrno() const { return fLastErrno; }                ///< Get error value for the last file error
    const char* GetLastError() const { return fLastError.c_str(); }        ///< Get error text for the last file error
 

--- a/include/TSharc.h
+++ b/include/TSharc.h
@@ -38,7 +38,7 @@ public:
       fZoffset = z;
    }
 
-   int     GetSize() const { return fHits.size(); } //!<!
+   int     GetSize() const { return GetMultiplicity(); } //!<!
 
    void Copy(TObject&) const override;        //!<!
    void Clear(Option_t* = "") override;       //!<!

--- a/include/TSharc2.h
+++ b/include/TSharc2.h
@@ -38,7 +38,7 @@ public:
       fZoffset = z;
    }
 
-   int     GetSize() const { return fHits.size(); } //!<!
+   int     GetSize() const { return Hits().size(); } //!<!
 
    void Copy(TObject&) const override;        //!<!
    void Clear(Option_t* = "") override;       //!<!
@@ -68,17 +68,7 @@ private:
 	// After that these vectors aren't used again.
    std::vector<TFragment> fFrontFragments; //!
    std::vector<TFragment> fBackFragments;  //!
-   //std::vector<TFragment> fPadFragments;   //!
 
-public:
-   /* //old from SHARC-1 class
-   static double GetDetectorThickness(TSharc2Hit& hit, double dist = -1.0); //!
-   static double GetDeadLayerThickness(TSharc2Hit& hit);                    //!
-   static double GetPadThickness(TSharc2Hit& hit);                          //!
-   static double GetPadDeadLayerThickness(TSharc2Hit& hit);                 //!
-   */
-
-private:
    static double fXoffset; //!<!
    static double fYoffset; //!<!
    static double fZoffset; //!<!

--- a/include/TSharc2Hit.h
+++ b/include/TSharc2Hit.h
@@ -39,10 +39,6 @@ public:
    ~TSharc2Hit() override;
 
 private:
-   // UShort_t   fDetectorNumber;  //
-   // UShort_t   fFrontStrip;     //
-   // UShort_t   fBackStrip;      //
-
    TDetectorHit fBackHit; //
    TDetectorHit fPadHit;  //
 
@@ -81,8 +77,6 @@ public:
    inline Double_t GetPadE() const { return GetPad().GetEnergy(); } //!<!
    inline Double_t GetPadT() const { return GetPad().GetTime(); }   //!<!
 
-   // std::pair<int,int>  GetPixel()  { return std::make_pair(fFrontStrip,fBackStrip);  }  //!<!
-
    Float_t GetFrontCharge() const
    {
       return TDetectorHit::GetCharge();
@@ -103,13 +97,6 @@ public:
       return GetTheta(Xoff, Yoff, Zoff) * TMath::RadToDeg();
    };                                                                          //!<!
    Double_t GetTheta(double Xoff = 0.0, double Yoff = 0.0, double Zoff = 0.0); //!<!
-
-   ///////////////////////////////////////////////////////////////////////
-   ///////////////////////////////////////////////////////////////////////
-   ///////////////////////////////////////////////////////////////////////
-   // void SetDetectorNumber(const UShort_t& det) { fDetectorNumber = det;   }  //!<!
-   // void SetFrontStrip(const UShort_t& strip)   { fFrontStrip    = strip; }  //!<!
-   // void SetBackStrip(const UShort_t& strip)    { fBackStrip     = strip; }  //!<!
 
    void SetFront(const TFragment& frag); //!<!
    void SetBack(const TFragment& frag);  //!<!

--- a/include/TSiLi.h
+++ b/include/TSiLi.h
@@ -57,7 +57,7 @@ public:
 
    void UseFitCharge()
    {
-      for(auto& fSiLiHit : fHits) {
+      for(auto& fSiLiHit : Hits()) {
          static_cast<TSiLiHit*>(fSiLiHit)->UseFitCharge();
       }
    }

--- a/include/TTigressHit.h
+++ b/include/TTigressHit.h
@@ -77,7 +77,7 @@ public:
    bool BGOFired() const { return fBgoFired; }
    void SetBGOFired(bool fired) { fBgoFired = fired; }
 
-   int GetTimeToTrigger() { return (fTimeStamp & 0x7fffff) - (static_cast<Int_t>(fCfd) >> 4); }
+   int GetTimeToTrigger() { return (GetTimeStamp() & 0x7fffff) - (static_cast<Int_t>(GetCfd()) >> 4); }
 
    int GetSegmentMultiplicity() const { return fSegments.size(); } //!<!
    int GetNSegments() const { return fSegments.size(); }           //!<!

--- a/include/TTrific.h
+++ b/include/TTrific.h
@@ -65,7 +65,6 @@ class TTrific : public TDetector {
 			fRange = 0;
    		}
 
-		virtual Short_t GetMultiplicity() const override {return fHits.size();}
 		virtual Short_t GetXMultiplicity() const {return fXFragments.size();}
 		virtual Short_t GetYMultiplicity() const {return fYFragments.size();}
 		virtual Short_t GetSingMultiplicity() const {return fSingFragments.size();}

--- a/libraries/TGRSIAnalysis/TCSM/TCSM.cxx
+++ b/libraries/TGRSIAnalysis/TCSM/TCSM.cxx
@@ -72,7 +72,7 @@ void TCSM::BuildHits()
          BuildVH(fFragment.second.at(i), hits[i]);
       }
    }
-   BuilddEE(hits, fHits);
+   BuilddEE(hits, Hits());
 }
 
 TVector3 TCSM::GetPosition(int detector, char pos, int horizontalstrip, int verticalstrip, double X, double Y, double Z)

--- a/libraries/TGRSIAnalysis/TDescant/TDescant.cxx
+++ b/libraries/TGRSIAnalysis/TDescant/TDescant.cxx
@@ -125,7 +125,7 @@ void TDescant::Print(Option_t*) const
 void TDescant::Print(std::ostream& out) const
 {
 	std::ostringstream str;
-   str<<fHits.size()<<" fHits"<<std::endl;
+   str<<GetMultiplicity()<<" hits"<<std::endl;
 	out<<str.str();
 }
 
@@ -139,7 +139,7 @@ void TDescant::AddFragment(const std::shared_ptr<const TFragment>& frag, TChanne
    }
 
    TDescantHit* hit = new TDescantHit(*frag);
-   fHits.push_back(hit);
+   AddHit(hit);
 }
 
 TVector3 TDescant::GetPosition(int DetNbr, double dist)

--- a/libraries/TGRSIAnalysis/TEmma/TEmma.cxx
+++ b/libraries/TGRSIAnalysis/TEmma/TEmma.cxx
@@ -68,7 +68,7 @@ void TEmma::Print(Option_t*) const
 void TEmma::Print(std::ostream& out) const
 {
 	std::ostringstream str;
-	str<<fHits.size()<<" fHits"<<std::endl;
+	str<<GetMultiplicity()<<" hits"<<std::endl;
 	out<<str.str();
 }
 
@@ -235,7 +235,7 @@ void TEmma::BuildHits()
 				hit->SetTop((hit->GetTop() - fAnodeTrigger));
 				hit->SetBottom((hit->GetBottom() - fAnodeTrigger));
 				hit->SetAnodeTrigger(fAnodeTrigger);
-				fHits.push_back(hit);
+				AddHit(hit);
 			} else {
 				//std::cout<<"TDC Array Failed"<<std::endl;
 				fFail = 0;
@@ -244,7 +244,7 @@ void TEmma::BuildHits()
 				if(hit->GetTop() == 0) fFail++;
 				if(hit->GetBottom() == 0) fFail++;
 				hit->SetFailedFill(fFail);
-				fHits.push_back(hit);
+				AddHit(hit);
 			}
 		} else {
 			return;
@@ -255,7 +255,6 @@ void TEmma::BuildHits()
 void TEmma::Clear(Option_t* opt)
 {
 	TDetector::Clear(opt);
-	fHits.clear();
 	fEmmaICHits.clear();
 	fEmmaAnodeHits.clear();
 	fEmmaTdcHits.clear();

--- a/libraries/TGRSIAnalysis/TGenericDetector/TGenericDetector.cxx
+++ b/libraries/TGRSIAnalysis/TGenericDetector/TGenericDetector.cxx
@@ -38,7 +38,7 @@ void TGenericDetector::AddFragment(const std::shared_ptr<const TFragment>& frag,
    }
 
    TDetectorHit* hit = new TDetectorHit(*frag);
-   fHits.push_back(hit);
+   AddHit(hit);
 }
 
 void TGenericDetector::Print(Option_t*) const

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
@@ -257,7 +257,7 @@ void TGriffin::Print(std::ostream& out) const
    str<<"Griffin Contains: "<<std::endl;
    str<<std::setw(6)<<GetLowGainMultiplicity()<<" Low gain hits"<<std::endl;
 	//if(TString(opt).Contains("all", TString::ECaseCompare::kIgnoreCase)) {
-		for(auto& hit : fGriffinLowGainHits) {
+		for(auto& hit : Hits()) {
 			static_cast<TGriffinHit*>(hit)->Print(str);
 		}
 	//}
@@ -305,7 +305,7 @@ void TGriffin::SetDefaultGainType(const EGainBits& gain_type)
 Short_t TGriffin::GetMultiplicity(const EGainBits& gain_type) const
 {
    switch(gain_type) {
-		case EGainBits::kLowGain: return fGriffinLowGainHits.size();
+		case EGainBits::kLowGain: return TDetector::GetMultiplicity();
 		case EGainBits::kHighGain: return fGriffinHighGainHits.size();
    };
    return 0;
@@ -314,19 +314,19 @@ Short_t TGriffin::GetMultiplicity(const EGainBits& gain_type) const
 const std::vector<TDetectorHit*>& TGriffin::GetHitVector(const EGainBits& gain_type) const
 {
    switch(gain_type) {
-		case EGainBits::kLowGain:  return fGriffinLowGainHits;
+		case EGainBits::kLowGain:  return Hits();
 		case EGainBits::kHighGain: return fGriffinHighGainHits;
    };
-	return fGriffinLowGainHits;
+	return Hits();
 }
 
 std::vector<TDetectorHit*>& TGriffin::GetHitVector(const EGainBits& gain_type)
 {
    switch(gain_type) {
-		case EGainBits::kLowGain:  return fGriffinLowGainHits;
+		case EGainBits::kLowGain:  return Hits();
 		case EGainBits::kHighGain: return fGriffinHighGainHits;
    };
-	return fGriffinLowGainHits;
+	return Hits();
 }
 
 std::vector<TDetectorHit*>& TGriffin::GetAddbackVector(const EGainBits& gain_type)

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
@@ -76,7 +76,7 @@ void TGriffinHit::Print(std::ostream& out) const
 	str<<"Griffin Detector: "<<GetDetector()<<std::endl
 		<<"Griffin Crystal:  "<<GetCrystal()<<std::endl
 		<<"Griffin Energy:   "<<GetEnergy()<<std::endl
-		<<"Griffin hit time:   "<<GetTime()<<", TS (in ns) "<<GetTimeStampNs()<<", TS "<<fTimeStamp<<std::endl
+		<<"Griffin hit time:   "<<GetTime()<<", TS (in ns) "<<GetTimeStampNs()<<", TS "<<GetTimeStamp()<<std::endl
 		<<"Griffin hit TV3 theta: "<<GetPosition().Theta() * 180 / (3.141597)<<" \tphi: "<<GetPosition().Phi() * 180 / (3.141597)<<std::endl;
 	out<<str.str();
 }

--- a/libraries/TGRSIAnalysis/TLaBr/TLaBr.cxx
+++ b/libraries/TGRSIAnalysis/TLaBr/TLaBr.cxx
@@ -95,7 +95,7 @@ void TLaBr::Print(Option_t*) const
 void TLaBr::Print(std::ostream& out) const
 {
 	std::ostringstream str;
-	str<<fHits.size()<<" fHits"<<std::endl;
+	str<<GetMultiplicity()<<" hits"<<std::endl;
 	out<<str.str();
 }
 
@@ -121,7 +121,7 @@ void TLaBr::ResetSuppressed()
 Short_t TLaBr::GetSuppressedMultiplicity(const TBgo* bgo)
 {
 	/// Automatically builds the suppressed hits using the fSuppressionCriterion and returns the number of suppressed hits
-	if(fHits.empty()) {
+	if(NoHits()) {
 		return 0;
 	}
 	// if the suppressed has been reset, clear the suppressed hits
@@ -132,7 +132,7 @@ Short_t TLaBr::GetSuppressedMultiplicity(const TBgo* bgo)
 		fSuppressedHits.clear();
 	}
 	if(fSuppressedHits.empty()) {
-		CreateSuppressed(bgo, fHits, fSuppressedHits);
+		CreateSuppressed(bgo, Hits(), fSuppressedHits);
 		SetSuppressed(true);
 	}
 
@@ -153,5 +153,5 @@ TLaBrHit* TLaBr::GetSuppressedHit(const int& i)
 void TLaBr::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel*)
 {
 	TLaBrHit* hit = new TLaBrHit(*frag);                 // Building is controlled in the constructor of the hit
-	fHits.push_back(hit);
+	AddHit(hit);
 }

--- a/libraries/TGRSIAnalysis/TPaces/TPaces.cxx
+++ b/libraries/TGRSIAnalysis/TPaces/TPaces.cxx
@@ -63,7 +63,7 @@ void TPaces::Print(Option_t*) const
 void TPaces::Print(std::ostream& out) const
 {
 	std::ostringstream str;
-	str<<fHits.size()<<" fHits"<<std::endl;
+	str<<GetMultiplicity()<<" hits"<<std::endl;
 	out<<str.str();
 }
 
@@ -76,6 +76,6 @@ TPaces& TPaces::operator=(const TPaces& rhs)
 void TPaces::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel*)
 {
 	TPacesHit* hit = new TPacesHit(*frag);
-	fHits.push_back(hit);
+	AddHit(hit);
 }
 

--- a/libraries/TGRSIAnalysis/TS3/TS3.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3.cxx
@@ -21,7 +21,8 @@ double TS3::fInnerDiameter  = 22.;
 double TS3::fTargetDistance = 31.;
 
 // Default tigress unpacking settings
-TTransientBits<UShort_t> TS3::fgS3Bits = static_cast<std::underlying_type<TS3::ES3GlobalBits>::type>(TS3::ES3GlobalBits::kMultHit);
+TTransientBits<UShort_t> TS3::fgS3Bits = TTransientBits<UShort_t>(static_cast<std::underlying_type<TS3::ES3GlobalBits>::type>(TS3::ES3GlobalBits::kMultHit));
+//TTransientBits<UShort_t> TS3::fgS3Bits = static_cast<UShort_t>(TS3::ES3GlobalBits::kMultHit);
 
 Int_t  TS3::fFrontBackTime = 75;
 double TS3::fFrontBackEnergy = 0.9;

--- a/libraries/TGRSIAnalysis/TSceptar/TSceptar.cxx
+++ b/libraries/TGRSIAnalysis/TSceptar/TSceptar.cxx
@@ -67,7 +67,7 @@ TSceptar& TSceptar::operator=(const TSceptar& rhs)
 void TSceptar::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel*)
 {
 	TSceptarHit* hit = new TSceptarHit(*frag); // Construction of TSceptarHit is handled in the constructor
-	fHits.push_back(hit);
+	AddHit(hit);
 }
 
 void TSceptar::Print(Option_t*) const
@@ -79,6 +79,6 @@ void TSceptar::Print(Option_t*) const
 void TSceptar::Print(std::ostream& out) const
 {
 	std::ostringstream str;
-	str<<fHits.size()<<" fHits"<<std::endl;
+	str<<GetMultiplicity()<<" hits"<<std::endl;
 	out<<str.str();
 }

--- a/libraries/TGRSIAnalysis/TSharc/TSharc.cxx
+++ b/libraries/TGRSIAnalysis/TSharc/TSharc.cxx
@@ -133,7 +133,7 @@ void TSharc::BuildHits()
 			TSharcHit* hit = new TSharcHit;
 			hit->SetFront(*front);
 			hit->SetBack(*back);
-			fHits.push_back(hit);
+			AddHit(hit);
 			front = fFrontFragments.erase(front);
 			back  = fBackFragments.erase(back);
 		} else {
@@ -141,7 +141,7 @@ void TSharc::BuildHits()
 		}
 	}
 
-	for(auto& fSharcHit : fHits) {
+	for(auto& fSharcHit : Hits()) {
 		for(pad = fPadFragments.begin(); pad != fPadFragments.end(); pad++) {
 			if(fSharcHit->GetDetector() == pad->GetDetector()) {
 				static_cast<TSharcHit*>(fSharcHit)->SetPad(*pad);
@@ -165,7 +165,6 @@ void TSharc::RemoveHits(std::vector<TSharcHit>* hits, std::set<int>* to_remove)
 void TSharc::Clear(Option_t* option)
 {
 	TDetector::Clear(option);
-	fHits.clear();
 
 	fFrontFragments.clear(); //!
 	fBackFragments.clear();  //!

--- a/libraries/TGRSIAnalysis/TSiLi/TSiLi.cxx
+++ b/libraries/TGRSIAnalysis/TSiLi/TSiLi.cxx
@@ -64,7 +64,7 @@ void TSiLi::Print(Option_t*) const
 void TSiLi::Print(std::ostream& out) const
 {
 	std::ostringstream str;
-   str<<fHits.size()<<" sili_hits"<<std::endl;
+   str<<GetMultiplicity()<<" sili_hits"<<std::endl;
    str<<fAddbackHits.size()<<" sili_addback_hits"<<std::endl;
 	out<<str.str();
 }
@@ -76,7 +76,7 @@ void TSiLi::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel* 
    }
 
    TSiLiHit* hit = new TSiLiHit(*frag); // Waveform fitting happens in ctor now
-   fHits.push_back(hit);
+   AddHit(hit);
 }
 
 // For mapping you may want to us -position.X() to account for looking upstream
@@ -166,7 +166,7 @@ Int_t TSiLi::GetAddbackMultiplicity()
 {
 	// Automatically builds the addback hits using the addback_criterion (if the size of the addback_hits vector is zero)
 	// and return the number of addback hits.
-	short basehits = fHits.size();
+	short basehits = GetMultiplicity();
 
 	// if the addback has been reset, clear the addback hits
 	if(fSiLiBits.TestBit(ESiLiBits::kAddbackSet)) {
@@ -285,9 +285,9 @@ void TSiLi::AddCluster(std::vector<unsigned>& cluster,bool ContainsReject)
 	}
 
 	if(cluster.size()>1&&!ContainsReject){
-		TSiLiHit* A=static_cast<TSiLiHit*>(fHits.at(cluster[0]));
-		TSiLiHit* B=static_cast<TSiLiHit*>(fHits.at(cluster[1]));
-		int rA=A->GetRing(),rB=B->GetRing();
+      TSiLiHit* A = static_cast<TSiLiHit*>(GetHit(cluster[0]));
+      TSiLiHit* B = static_cast<TSiLiHit*>(GetHit(cluster[1]));
+      int rA=A->GetRing(),rB=B->GetRing();
 		int sA=A->GetSector(),sB=B->GetSector();
 		int rAB=std::abs(rA-rB);
 		int sAB=std::abs(sA-sB);
@@ -295,10 +295,10 @@ void TSiLi::AddCluster(std::vector<unsigned>& cluster,bool ContainsReject)
 
 		if(cluster.size()==2){
 			//Reject events with missing middle pixel
-			if(rAB+sAB>1)ContainsReject=true;
-		}else{
-			TSiLiHit* C=static_cast<TSiLiHit*>(fHits.at(cluster[2]));
-			int rC=C->GetRing();
+         if(rAB + sAB > 1) ContainsReject = true;
+      }else{
+         TSiLiHit* C  = static_cast<TSiLiHit*>(GetHit(cluster[2]));
+         int rC=C->GetRing();
 			int sC=C->GetSector();
 			int rAC=std::abs(rA-rC),rBC=std::abs(rB-rC);
 			int sAC=std::abs(sA-sC),sBC=std::abs(sB-sC);

--- a/libraries/TGRSIAnalysis/TTAC/TTAC.cxx
+++ b/libraries/TGRSIAnalysis/TTAC/TTAC.cxx
@@ -45,12 +45,12 @@ void TTAC::Print(Option_t*) const
 void TTAC::Print(std::ostream& out) const
 {
 	std::ostringstream str;
-	str<<fHits.size()<<" fHits"<<std::endl;
+	str<<GetMultiplicity()<<" hits"<<std::endl;
 	out<<str.str();
 }
 
 void TTAC::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel*)
 {
 	TTACHit* hit = new TTACHit(*frag);
-	fHits.push_back(hit);
+	AddHit(hit);
 }

--- a/libraries/TGRSIAnalysis/TTAC/TTACHit.cxx
+++ b/libraries/TGRSIAnalysis/TTAC/TTACHit.cxx
@@ -75,8 +75,8 @@ Double_t TTACHit::GetTempCorrectedEnergy(TGraph* correction_graph) const {
 	if(channel == nullptr) {
 		return 0.0;
 	}
-	if(fKValue > 0) {
-		return channel->CalibrateENG(TempCorrectedCharge(correction_graph), (int)fKValue);
+	if(GetKValue() > 0) {
+		return channel->CalibrateENG(TempCorrectedCharge(correction_graph), static_cast<int>(GetKValue()));
 	} else if(channel->UseCalFileIntegration()) {
 		return channel->CalibrateENG(TempCorrectedCharge(correction_graph), 0);
 	}

--- a/libraries/TGRSIAnalysis/TTip/TTip.cxx
+++ b/libraries/TGRSIAnalysis/TTip/TTip.cxx
@@ -173,7 +173,7 @@ void TTip::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel* c
 
    TTipHit* hit = new TTipHit(*frag);
    hit->SetUpNumbering(chan);          // Think about moving this to ctor
-   fHits.push_back(hit);
+   AddHit(hit);
 }
 
 void TTip::Print(Option_t*) const
@@ -185,7 +185,7 @@ void TTip::Print(Option_t*) const
 void TTip::Print(std::ostream& out) const
 {
 	std::ostringstream str;
-   str<<fHits.size()<<" fHits"<<std::endl;
+   str<<GetMultiplicity()<<" hits"<<std::endl;
 	out<<str.str();
 }
 

--- a/libraries/TGRSIAnalysis/TTrific/TTrific.cxx
+++ b/libraries/TGRSIAnalysis/TTrific/TTrific.cxx
@@ -82,7 +82,7 @@ void TTrific::Print(Option_t*) const
 void TTrific::Print(std::ostream& out) const
 {
 	std::ostringstream str;
-	str<<fHits.size()<<" fHits"<<std::endl;
+	str<<GetMultiplicity()<<" hits"<<std::endl;
 	str<<fXFragments.size()<<" xHits"<<std::endl;
 	str<<fYFragments.size()<<" yHits"<<std::endl;
 	str<<fSingFragments.size()<<" singHits"<<std::endl;
@@ -114,7 +114,7 @@ void TTrific::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel
 			break;
 	};
 
-	fHits.push_back(hit);
+	AddHit(hit);
 	
 	return;
 }
@@ -123,7 +123,6 @@ void TTrific::Clear(Option_t* option)
 {
 
 	TDetector::Clear(option);
-	fHits.clear();
 	
 	fXFragments.clear(); //!
 	fYFragments.clear(); //!

--- a/libraries/TGRSIAnalysis/TZeroDegree/TZeroDegree.cxx
+++ b/libraries/TGRSIAnalysis/TZeroDegree/TZeroDegree.cxx
@@ -50,7 +50,7 @@ void TZeroDegree::Print(Option_t*) const
 void TZeroDegree::Print(std::ostream& out) const
 {
 	std::ostringstream str;
-	str<<"TZeroDegree contains "<<fHits.size()<<" fHits"<<std::endl;
+	str<<"TZeroDegree contains "<<GetMultiplicity()<<" hits"<<std::endl;
 	out<<str.str();
 }
 
@@ -63,5 +63,5 @@ void TZeroDegree::AddFragment(const std::shared_ptr<const TFragment>& frag, TCha
    }
 
    TZeroDegreeHit* hit = new TZeroDegreeHit(*frag);
-   fHits.push_back(hit);
+   AddHit(hit);
 }

--- a/libraries/TGRSIDataParser/TGRSIDataParser.cxx
+++ b/libraries/TGRSIDataParser/TGRSIDataParser.cxx
@@ -1999,12 +1999,12 @@ int TGRSIDataParser::EPIXToScalar(float* data, int size, unsigned int midasSeria
 	int                         NumFragsFound = 1;
 	std::shared_ptr<TEpicsFrag> EXfrag        = std::make_shared<TEpicsFrag>();
 
-	EXfrag->fDaqTimeStamp = midasTime;
-	EXfrag->fDaqId        = midasSerialNumber;
+	EXfrag->DaqTimeStamp(midasTime);
+	EXfrag->DaqId(midasSerialNumber);
 
 	for(int x = 0; x < size; x++) {
-		EXfrag->fData.push_back(data[x]);
-		EXfrag->fName.push_back(TEpicsFrag::GetEpicsVariableName(x));
+		EXfrag->AddData(data[x]);
+		EXfrag->AddName(TEpicsFrag::GetEpicsVariableName(x));
 	}
 
 	fScalerOutputQueue->Push(EXfrag);

--- a/libraries/TGRSIFormat/TGRSIMnemonic.cxx
+++ b/libraries/TGRSIFormat/TGRSIMnemonic.cxx
@@ -94,9 +94,9 @@ void TGRSIMnemonic::EnumerateSystem()
       }
    } else if(SystemString().compare("TF") == 0) {
       fSystem = ESystem::kTrific;
-   }  else if(fSystemString.compare("SZ") == 0) {
+   }  else if(SystemString().compare("SZ") == 0) {
       fSystem = ESystem::kSharc2;
-   }  else if(fSystemString.compare("RC") == 0) {  
+   }  else if(SystemString().compare("RC") == 0) {  
       fSystem = ESystem::kRcmp;
    }  else {
       fSystem = ESystem::kClear;

--- a/libraries/TGRSIFormat/TGRSIMnemonic.cxx
+++ b/libraries/TGRSIFormat/TGRSIMnemonic.cxx
@@ -24,6 +24,7 @@
 #include "TLaBrBgo.h"
 #include "TEmma.h"
 #include "TTrific.h"
+#include "TRcmp.h"
 
 ClassImp(TGRSIMnemonic)
 
@@ -37,37 +38,37 @@ void TGRSIMnemonic::EnumerateSystem()
 {
    // Enumerating the fSystemString must come after the total mnemonic has been parsed as the details of other parts of
    // the mnemonic must be known
-   if(fSystemString.compare("TI") == 0) {
+   if(SystemString().compare("TI") == 0) {
       fSystem = ESystem::kTigress;
-   } else if(fSystemString.compare("SH") == 0) {
+   } else if(SystemString().compare("SH") == 0) {
       fSystem = ESystem::kSharc;
-   } else if(fSystemString.compare("TR") == 0) {
+   } else if(SystemString().compare("TR") == 0) {
       fSystem = ESystem::kTriFoil;
-   } else if(fSystemString.compare("RF") == 0) {
+   } else if(SystemString().compare("RF") == 0) {
       fSystem = ESystem::kRF;
-   } else if(fSystemString.compare("SP") == 0) {
+   } else if(SystemString().compare("SP") == 0) {
       if(SubSystem() == EMnemonic::kI) {
          fSystem = ESystem::kSiLi;
       } else {
          fSystem = ESystem::kSiLiS3;
       }
-   } else if(fSystemString.compare("GD") == 0) {
+   } else if(SystemString().compare("GD") == 0) {
          fSystem = ESystem::kGeneric;
-   } else if(fSystemString.compare("CS") == 0) {
+   } else if(SystemString().compare("CS") == 0) {
       fSystem = ESystem::kCSM;
-   } else if(fSystemString.compare("GR") == 0) {
+   } else if(SystemString().compare("GR") == 0) {
       if(SubSystem() == EMnemonic::kS) {
 			fSystem = ESystem::kGriffinBgo;
 		} else {
 			fSystem = ESystem::kGriffin;
 		}
-   } else if(fSystemString.compare("SE") == 0) {
+   } else if(SystemString().compare("SE") == 0) {
       fSystem = ESystem::kSceptar;
-   } else if(fSystemString.compare("PA") == 0) {
+   } else if(SystemString().compare("PA") == 0) {
       fSystem = ESystem::kPaces;
-   } else if(fSystemString.compare("DS") == 0) {
+   } else if(SystemString().compare("DS") == 0) {
       fSystem = ESystem::kDescant;
-   } else if((fSystemString.compare("DA") == 0) || (fSystemString.compare("LB") == 0) ) {
+   } else if((SystemString().compare("DA") == 0) || (SystemString().compare("LB") == 0) ) {
       if(SubSystem() == EMnemonic::kS) {
 			fSystem = ESystem::kLaBrBgo;
 		} else if(SubSystem() == EMnemonic::kT) {
@@ -75,23 +76,25 @@ void TGRSIMnemonic::EnumerateSystem()
 		} else {
 			fSystem = ESystem::kLaBr;
 		}
-   } else if(fSystemString.compare("BA") == 0) {
+   } else if(SystemString().compare("BA") == 0) {
       fSystem = ESystem::kS3;
-   } else if(fSystemString.compare("ZD") == 0) {
+   } else if(SystemString().compare("ZD") == 0) {
       fSystem = ESystem::kZeroDegree;
-   } else if(fSystemString.compare("TP") == 0) {
+   } else if(SystemString().compare("TP") == 0) {
       fSystem = ESystem::kTip;
-   } else if(fSystemString.compare("BG") == 0) {
+   } else if(SystemString().compare("BG") == 0) {
       fSystem = ESystem::kBgo;
-   } else if((fSystemString.compare("EM") == 0) || (fSystemString.compare("ET") == 0)) {
+   } else if((SystemString().compare("EM") == 0) || (SystemString().compare("ET") == 0)) {
       if(SubSystem() == EMnemonic::kE) {
         fSystem = ESystem::kEmmaS3;
       }
       else {
         fSystem = ESystem::kEmma;
       }
-   } else if(fSystemString.compare("TF") == 0) {
+   } else if(SystemString().compare("TF") == 0) {
       fSystem = ESystem::kTrific;
+   } else if(SystemString().compare("RC") == 0) {
+      fSystem = ESystem::kRcmp;
    } else {
       fSystem = ESystem::kClear;
    }
@@ -147,7 +150,7 @@ void TGRSIMnemonic::Parse(std::string* name)
    if(fSystem == ESystem::kSiLi) {
 		std::string buf;
       buf.assign(*name, 7, 2);
-      fSegment = static_cast<uint16_t>(strtol(buf.c_str(), nullptr, 16));
+      Segment(static_cast<int16_t>(strtol(buf.c_str(), nullptr, 16)));
    }
 
    return;
@@ -157,49 +160,44 @@ void TGRSIMnemonic::Print(Option_t*) const
 {
 	std::ostringstream str;
    str<<"======== GRSIMNEMONIC ========"<<std::endl;
-   str<<"fArrayPosition           = "<<fArrayPosition<<std::endl;
-   str<<"fSegment                 = "<<fSegment<<std::endl;
-   str<<"fSystemString            = "<<fSystemString<<std::endl;
-   str<<"fSubSystemString         = "<<fSubSystemString<<std::endl;
-   str<<"fArraySubPositionString  = "<<fArraySubPositionString<<std::endl;
-   str<<"fCollectedChargeString   = "<<fCollectedChargeString<<std::endl;
-   str<<"fOutputSensorString      = "<<fOutputSensorString<<std::endl;
+	TMnemonic::Print(str);
    str<<"=============================="<<std::endl;
 	std::cout<<str.str();
 }
 
 TClass* TGRSIMnemonic::GetClassType() const
 {
-   if(fClassType != nullptr) {
-      return fClassType;
+   if(TMnemonic::GetClassType() != nullptr) {
+      return TMnemonic::GetClassType();
    }
 
    switch(System()) {
-		case ESystem::kTigress:       fClassType = TTigress::Class(); break;
-		case ESystem::kSharc:         fClassType = TSharc::Class(); break;
-		case ESystem::kTriFoil:       fClassType = TTriFoil::Class(); break;
-		case ESystem::kRF:            fClassType = TRF::Class(); break;
-		case ESystem::kSiLi:          fClassType = TSiLi::Class(); break;
-		case ESystem::kS3:            fClassType = TS3::Class(); break;
-		case ESystem::kSiLiS3:        fClassType = TS3::Class(); break;
-		case ESystem::kCSM:           fClassType = TCSM::Class(); break;
-		case ESystem::kGriffin:       fClassType = TGriffin::Class(); break;
-		case ESystem::kSceptar:       fClassType = TSceptar::Class(); break;
-		case ESystem::kPaces:         fClassType = TPaces::Class(); break;
-		case ESystem::kDescant:       fClassType = TDescant::Class(); break;
-		case ESystem::kLaBr:          fClassType = TLaBr::Class(); break;
-		case ESystem::kTAC:           fClassType = TTAC::Class(); break;
-		case ESystem::kZeroDegree:    fClassType = TZeroDegree::Class(); break;
-		case ESystem::kTip:           fClassType = TTip::Class(); break;
-		case ESystem::kGriffinBgo:    fClassType = TGriffinBgo::Class(); break;
-		case ESystem::kLaBrBgo:       fClassType = TLaBrBgo::Class(); break;
-		case ESystem::kGeneric:       fClassType = TGenericDetector::Class(); break;
-		case ESystem::kEmma:          fClassType = TEmma::Class(); break;
-		case ESystem::kEmmaS3:        fClassType = TS3::Class(); break;
-		case ESystem::kTrific:        fClassType = TTrific::Class(); break;
-		default:                      fClassType = nullptr;
+		case ESystem::kTigress:       SetClassType(TTigress::Class()); break;
+		case ESystem::kSharc:         SetClassType(TSharc::Class()); break;
+		case ESystem::kTriFoil:       SetClassType(TTriFoil::Class()); break;
+		case ESystem::kRF:            SetClassType(TRF::Class()); break;
+		case ESystem::kSiLi:          SetClassType(TSiLi::Class()); break;
+		case ESystem::kS3:            SetClassType(TS3::Class()); break;
+		case ESystem::kSiLiS3:        SetClassType(TS3::Class()); break;
+		case ESystem::kCSM:           SetClassType(TCSM::Class()); break;
+		case ESystem::kGriffin:       SetClassType(TGriffin::Class()); break;
+		case ESystem::kSceptar:       SetClassType(TSceptar::Class()); break;
+		case ESystem::kPaces:         SetClassType(TPaces::Class()); break;
+		case ESystem::kDescant:       SetClassType(TDescant::Class()); break;
+		case ESystem::kLaBr:          SetClassType(TLaBr::Class()); break;
+		case ESystem::kTAC:           SetClassType(TTAC::Class()); break;
+		case ESystem::kZeroDegree:    SetClassType(TZeroDegree::Class()); break;
+		case ESystem::kTip:           SetClassType(TTip::Class()); break;
+		case ESystem::kGriffinBgo:    SetClassType(TGriffinBgo::Class()); break;
+		case ESystem::kLaBrBgo:       SetClassType(TLaBrBgo::Class()); break;
+		case ESystem::kGeneric:       SetClassType(TGenericDetector::Class()); break;
+		case ESystem::kEmma:          SetClassType(TEmma::Class()); break;
+		case ESystem::kEmmaS3:        SetClassType(TS3::Class()); break;
+		case ESystem::kTrific:        SetClassType(TTrific::Class()); break;
+		case ESystem::kRcmp:          SetClassType(TRcmp::Class()); break;
+		default:                      SetClassType(nullptr);
    };
-   return fClassType;
+   return TMnemonic::GetClassType();
 }
 
 double TGRSIMnemonic::GetTime(Long64_t timestamp, Float_t cfd, double energy, const TChannel* channel) const
@@ -241,7 +239,7 @@ int TGRSIMnemonic::NumericArraySubPosition() const
 	/// Except for the LaBr BGOs which use A - 0, B - 1, C - 2
 	/// and a default of 5
 	if(System() == ESystem::kLaBrBgo) {
-		switch(fArraySubPosition) {
+		switch(ArraySubPosition()) {
 			case TMnemonic::EMnemonic::kA:
 				return 0;
 			case TMnemonic::EMnemonic::kB:
@@ -253,7 +251,7 @@ int TGRSIMnemonic::NumericArraySubPosition() const
 		};
 	}
 
-	switch(fArraySubPosition) {
+	switch(ArraySubPosition()) {
 		case TMnemonic::EMnemonic::kB:
 			return 0;
 		case TMnemonic::EMnemonic::kG:

--- a/libraries/TMidas/TMidasEvent.cxx
+++ b/libraries/TMidas/TMidasEvent.cxx
@@ -34,8 +34,6 @@ TMidasEvent::TMidasEvent()
    fEventHeader.fSerialNumber = 0;
    fEventHeader.fTimeStamp    = 0;
    fEventHeader.fDataSize     = 0;
-
-   fGoodFrags = 0;
 }
 
 void TMidasEvent::Copy(TObject& rhs) const
@@ -98,7 +96,7 @@ void TMidasEvent::Clear(Option_t*)
    fEventHeader.fTimeStamp    = 0;
    fEventHeader.fDataSize     = 0;
 
-   fGoodFrags = 0;
+	TRawEvent::Clear();
 }
 
 void TMidasEvent::SetData(uint32_t size, char* data)

--- a/libraries/TMidas/TMidasFile.cxx
+++ b/libraries/TMidas/TMidasFile.cxx
@@ -674,7 +674,13 @@ void TMidasFile::SetFileOdb()
       return;
    }
 
-   fOdb = new TXMLOdb(fOdbEvent->GetData(), fOdbEvent->GetDataSize());
+	try {
+		fOdb = new TXMLOdb(fOdbEvent->GetData(), fOdbEvent->GetDataSize());
+	} catch(std::exception& e) {
+		std::cout<<"Got exception '"<<e.what()<<"' trying to read "<<fOdbEvent->GetDataSize()<<" bytes (or words?) from:"<<std::endl;
+		std::cout<<fOdbEvent->GetData()<<std::endl;
+		throw e;
+	}
    TChannel::DeleteAllChannels();
 
    SetRunInfo(fOdbEvent->GetTimeStamp());
@@ -830,7 +836,6 @@ void TMidasFile::SetGRIFFOdb()
          tempChan->SetAddress(address.at(x));
          tempChan->SetNumber(TPriorityValue<int>(x, EPriority::kRootFile));
 
-         tempChan->SetUserInfoNumber(TPriorityValue<int>(x, EPriority::kRootFile));
          tempChan->AddENGCoefficient(offsets.at(x));
          tempChan->AddENGCoefficient(gains.at(x));
 			if(x < quads.size()) {
@@ -1000,7 +1005,6 @@ void TMidasFile::SetTIGOdb()
          }
       }
       tempChan->SetIntegration(TPriorityValue<int>(temp_integration, EPriority::kRootFile));
-      tempChan->SetUserInfoNumber(TPriorityValue<int>(x, EPriority::kRootFile));
       tempChan->AddENGCoefficient(offsets.at(x));
       tempChan->AddENGCoefficient(gains.at(x));
 
@@ -1083,7 +1087,6 @@ void TMidasFile::SetTIGDAQOdb()  // Basically a copy of the GRIFFIN one without 
          tempChan->SetAddress(address.at(x));
          tempChan->SetNumber(TPriorityValue<int>(x, EPriority::kRootFile));
 
-         tempChan->SetUserInfoNumber(TPriorityValue<int>(x, EPriority::kRootFile));
          tempChan->AddENGCoefficient(offsets.at(x));
          tempChan->AddENGCoefficient(gains.at(x));
          if(x < quads.size()) tempChan->AddENGCoefficient(quads.at(x)); //Assuming this means quad terms won't be added if not there. 

--- a/libraries/TMidas/TXMLOdb.cxx
+++ b/libraries/TMidas/TXMLOdb.cxx
@@ -30,13 +30,11 @@ TXMLOdb::TXMLOdb(char* buffer, int size)
    }
    fDoc = fParser->GetXMLDocument();
    if(fDoc == nullptr) {
-      fprintf(stderr, "XmlOdb::XmlOdb: Malformed ODB dump: cannot get XML document\n");
-      return;
+		std::runtime_error("XmlOdb::XmlOdb: Malformed ODB dump: cannot get XML document");
    }
    fOdb = fDoc->GetRootNode();
    if(strcmp(fOdb->GetNodeName(), "odb") != 0) {
-      fprintf(stderr, "XmlOdb::XmlOdb: Malformed ODB dump: cannot find <odb> tag\n");
-      return;
+      std::runtime_error("XmlOdb::XmlOdb: Malformed ODB dump: cannot find <odb> tag");
    }
 }
 

--- a/makefile
+++ b/makefile
@@ -87,7 +87,7 @@ CFLAGS    += $(shell root-config --cflags)
 CFLAGS    += -MMD -MP $(INCLUDES)
 LINKFLAGS += $(shell root-config --glibs) -lSpectrum -lMinuit -lGuiHtml -lTreePlayer -lX11 -lXpm -lProof -lTMVA
 LINKFLAGS += $(shell grsi-config --all-libs)
-LINKFLAGS += $(shell grsi-config --GRSIData-libs)
+#LINKFLAGS += $(shell grsi-config --GRSIData-libs)
 
 # RCFLAGS are being used for rootcint
 ifeq ($(MATHMORE_INSTALLED),yes)
@@ -149,10 +149,10 @@ doxygen:
 	$(MAKE) -C $@
 
 $(GRSISYS)/bin/%: .build/myAnalysis/%.o | $(LIBRARY_OUTPUT) include/GRSIDataVersion.h lib/libGRSIData.so
-	$(call run_and_test,$(CPP) $< -o $@ $(LINKFLAGS),$@,$(COM_COLOR),$(COM_STRING),$(OBJ_COLOR) )
+	$(call run_and_test,$(CPP) $< -o $@ $(LINKFLAGS) $(shell grsi-config --GRSIData-libs),$@,$(COM_COLOR),$(COM_STRING),$(OBJ_COLOR) )
 
 $(GRSISYS)/bin/%: .build/util/%.o | $(LIBRARY_OUTPUT) include/GRSIDataVersion.h lib/libGRSIData.so
-	$(call run_and_test,$(CPP) $< -o $@ $(LINKFLAGS),$@,$(COM_COLOR),$(COM_STRING),$(OBJ_COLOR) )
+	$(call run_and_test,$(CPP) $< -o $@ $(LINKFLAGS) $(shell grsi-config --GRSIData-libs),$@,$(COM_COLOR),$(COM_STRING),$(OBJ_COLOR) )
 
 lib: include/GRSIDataVersion.h
 	@mkdir -p $@

--- a/util/GriffinCTFix.cxx
+++ b/util/GriffinCTFix.cxx
@@ -211,6 +211,7 @@ void FixAll(TFile* inputFile, double energy)
 {
    // This function loops over 16 clovers (always does) and by default uses the 1332 keV gamma ray in 60Co
    for(int d = 1; d <= 16; d++) {
+		std::cout << "Starting CrossTalkFix for detector "<<d<<", using energy "<<energy<<std::endl;
       CrossTalkFix(d, energy, inputFile);
    }
 }
@@ -254,5 +255,8 @@ int main(int argc, char** argv)
 
    // This function writes a corrections cal_file which can be loaded in with your normal cal file.
    TChannel::WriteCTCorrections("ct_correction.cal");
+
+	outputFile->Write();
+	outputFile->Close();
 }
 #endif


### PR DESCRIPTION
Since most protected members in the parent classes are now private, the child classes have to use the proper access functions instead of using the members directly.

Also added the creation of the compile_commands.json file to the CMakeLists.txt file (to be able to use clang-format and clang-tidy on this repository as well).

Since the new config scripts check which libraries exist, calling them at the beginning of make returns no libraries at all, so the makefile was adjusted to call the config scripts for each compile command instead of calling it once (at the beginning) and storing the result.

The TXMLOdb constructor throws an exception if it can't get the XML document or the odb tag is missing (instead of just returning from the constructor)