### PR TITLE
Fixed #100

### DIFF
--- a/util/GriffinCTFix.cxx
+++ b/util/GriffinCTFix.cxx
@@ -247,7 +247,9 @@ int main(int argc, char** argv)
    auto        lastSlash      = outputFileName.find_last_of('/');
    if(lastSlash != std::string::npos) {
       outputFileName = std::string("ct_") + outputFileName.substr(lastSlash + 1);
-   }
+   } else {
+		outputFileName = std::string("ct_") + std::string(argv[1]);
+	}
 
    auto* outputFile = new TFile(outputFileName.c_str(), "recreate");
 


### PR DESCRIPTION
It now doesn't matter whether a leading "./" is used or not. One can also supply a parameter file (.par extension) with user settings. If this file contains a setting for "CrossTalkEnergy" that energy will be used instead of 1332. 