### PR TITLE
Added support for wall configuration of Descant detectors

### DIFF
--- a/include/TDescant.h
+++ b/include/TDescant.h
@@ -58,6 +58,7 @@ private:
 
    static std::array<TVector3, 71> fPosition;            //!<!
    static std::array<TVector3, 9>  fAncillaryPosition;   //!<!
+   static std::array<TVector3, 60> fWallPosition;   //!<!
 
    /// \cond CLASSIMP
    ClassDefOverride(TDescant, 1)   // NOLINT(readability-else-after-return)

--- a/include/TGRSIDetectorInformation.h
+++ b/include/TGRSIDetectorInformation.h
@@ -37,6 +37,8 @@ public:
 
    inline void SetDescantAncillary(bool flag = true) { fDescantAncillary = flag; }
    inline bool DescantAncillary() const { return fDescantAncillary; }
+   inline void SetDescantWall(bool flag = true) { fDescantAncillary = flag; }
+   inline bool DescantWall() const { return fDescantWall; }
 
    inline void SetTigress(bool flag = true) { fTigress = flag; }
    inline void SetSharc(bool flag = true) { fSharc = flag; }
@@ -91,6 +93,8 @@ private:
    //  for more info, see: https://www.triumf.info/wiki/tigwiki/index.php/Detector_Nomenclature
 
    bool fDescantAncillary{false};   ///< Descant is in the ancillary detector locations
+   bool fDescantWall{false};   ///< Descant is in the wall detector locations
+
 
    bool fTigress{false};   ///< flag for Tigress on/off
    bool fSharc{false};     ///< flag for Sharc on/off

--- a/libraries/TGRSIAnalysis/TDescant/TDescant.cxx
+++ b/libraries/TGRSIAnalysis/TDescant/TDescant.cxx
@@ -37,6 +37,7 @@ std::array<TVector3, 71> TDescant::fPosition = {
    TVector3(-288.6, -325.6, 246.5), TVector3(-188.8, -382.5, 260.9), TVector3(-72.1, -420.4, 260.9),
    TVector3(42.1, -433.0, 246.5), TVector3(220.4, -375.0, 246.5), TVector3(305.4, -297.7, 260.9),
    TVector3(377.5, -198.5, 260.9), TVector3(424.8, -93.8, 246.5)};
+
 std::array<TVector3, 9> TDescant::fAncillaryPosition = {
    // Ancillary detector locations from Evan.
    TVector3(TMath::Sin(TMath::DegToRad() * (0.0)) * TMath::Cos(TMath::DegToRad() * (0.0)),
@@ -69,6 +70,29 @@ std::array<TVector3, 9> TDescant::fAncillaryPosition = {
    TVector3(TMath::Sin(TMath::DegToRad() * (125.2644)) * TMath::Cos(TMath::DegToRad() * (292.5)),
             TMath::Sin(TMath::DegToRad() * (125.2644)) * TMath::Sin(TMath::DegToRad() * (292.5)),
             TMath::Cos(TMath::DegToRad() * (125.2644)))};
+
+std::array<TVector3, 60> TDescant::fWallPosition = {
+   // Descant detectors in wall configuration
+   TVector3(-922.311, -985.674, -1317.2),  TVector3(-922.311, -492.837, -1317.2), TVector3(-922.311, 0, -1317.2),
+   TVector3(-922.311, 492.837, -1317.2),   TVector3(-922.311, 985.674, -1317.2),  TVector3(-1213.57, -985.674, -1054.94),
+   TVector3(-1213.57, -492.837, -1054.94), TVector3(-1213.57, 0, -1054.94),       TVector3(-1213.57, 492.837, -1054.94),
+   TVector3(-1213.57, 985.674, -1054.94),  TVector3(-1213.57, -985.674, 1054.94), TVector3(-1213.57, -492.837, 1054.94),
+   TVector3(-1213.57, 0, 1054.94),         TVector3(-1213.57, 492.837, 1054.94),  TVector3(-1213.57, 985.674, 1054.94),
+   TVector3(-922.311, -985.674, 1317.2),   TVector3(-922.311, -492.837, 1317.2),  TVector3(-922.311, 0, 1317.2),
+   TVector3(-922.311, 492.837, 1317.2),    TVector3(-922.311, 985.674, 1317.2),   TVector3(-576.256, -985.674, 1501.2),
+   TVector3(-576.256, -492.837, 1501.2),   TVector3(-576.256, 0, 1501.2),         TVector3(-576.256, 492.837, 1501.2),
+   TVector3(-576.256, 985.674, 1501.2),    TVector3(-195.966, -985.674, 1596.01), TVector3(-195.966, -492.837, 1596.01),
+   TVector3(-195.966, 0, 1596.01),         TVector3(-195.966, 492.837, 1596.01),  TVector3(-195.966, 985.674, 1596.01),
+   TVector3(195.966, -985.674, 1596.01),   TVector3(195.966, -492.837, 1596.01),  TVector3(195.966, 0, 1596.01),
+   TVector3(195.966, 492.837, 1596.01),    TVector3(195.966, 985.674, 1596.01),   TVector3(576.256, -985.674, 1501.2),
+   TVector3(576.256, -492.837, 1501.2),    TVector3(576.256, 0, 1501.2),          TVector3(576.256, 492.837, 1501.2),
+   TVector3(576.256, 985.674, 1501.2),     TVector3(922.311, -985.674, 1317.2),   TVector3(922.311, -492.837, 1317.2),
+   TVector3(922.311, 0, 1317.2),           TVector3(922.311, 492.837, 1317.2),    TVector3(922.311, 985.674, 1317.2),
+   TVector3(1213.57, -985.674, 1054.94),   TVector3(1213.57, -492.837, 1054.94),  TVector3(1213.57, 0, 1054.94),
+   TVector3(1213.57, 492.837, 1054.94),    TVector3(1213.57, 985.674, 1054.94),   TVector3(1213.57, -985.674, -1054.94),
+   TVector3(1213.57, -492.837, -1054.94),  TVector3(1213.57, 0, -1054.94),        TVector3(1213.57, 492.837, -1054.94),
+   TVector3(1213.57, 985.674, -1054.94),   TVector3(922.311, -985.674, -1317.2),  TVector3(922.311, -492.837, -1317.2),
+   TVector3(922.311, 0, -1317.2),          TVector3(922.311, 492.837, -1317.2),   TVector3(922.311, 985.674, -1317.2)};
 
 TDescant::TDescant()
 {
@@ -129,7 +153,6 @@ TVector3 TDescant::GetPosition(int DetNbr, double dist)
 {
    // Gets the position vector for detector DetNbr
    // dist is only used when detectors are in the ancillary positions.
-
    if(TRunInfo::GetDetectorInformation() != nullptr && static_cast<TGRSIDetectorInformation*>(TRunInfo::GetDetectorInformation())->DescantAncillary()) {
       if(DetNbr > 8) {
          return {0, 0, 1};
@@ -141,5 +164,12 @@ TVector3 TDescant::GetPosition(int DetNbr, double dist)
    if(DetNbr > 70) {
       return {0, 0, 1};
    }
+   if(TRunInfo::GetDetectorInformation() != nullptr && static_cast<TGRSIDetectorInformation*>(TRunInfo::GetDetectorInformation())->DescantWall()) {
+      if (DetNbr > 60) {
+         return {0, 0, 1};
+      }
+      return fWallPosition[DetNbr];
+   }
+
    return fPosition[DetNbr];
 }

--- a/libraries/TGRSIFormat/TGRSIDetectorInformation.cxx
+++ b/libraries/TGRSIFormat/TGRSIDetectorInformation.cxx
@@ -33,6 +33,7 @@ void TGRSIDetectorInformation::Print(Option_t* opt) const
    if(strchr(opt, 'a') != nullptr) {
       std::ostringstream str;
       str << DBLUE << "\t\tDESCANT in ancillary positions = " << DRED << (DescantAncillary() ? "TRUE" : "FALSE") << RESET_COLOR << std::endl;
+      str << DBLUE << "\t\tDESCANT in wall configuration = " << DRED << (DescantWall() ? "TRUE" : "FALSE") << RESET_COLOR << std::endl;
       str << std::endl;
       str << "\t\tTIGRESS:            " << (Tigress() ? "true" : "false") << std::endl;
       str << "\t\tSHARC:              " << (Sharc() ? "true" : "false") << std::endl;
@@ -91,6 +92,7 @@ void TGRSIDetectorInformation::Clear(Option_t*)
    fRcmp       = false;
 
    fDescantAncillary = false;
+   fDescantWall = false;
 }
 
 void TGRSIDetectorInformation::Set()


### PR DESCRIPTION
 I tried to add the descant wall configuration to GRSIData by mimicking the ancillary positon setup as accurately as possible.