### PR TITLE
Removed high gain hits from TGriffin

### DIFF
--- a/histos/MakeGriffinHistograms.cxx
+++ b/histos/MakeGriffinHistograms.cxx
@@ -259,13 +259,9 @@ extern "C" void MakeAnalysisHistograms(TRuntimeObjects& obj)
       }
    }
    if(grif != nullptr) {
-      for(auto g1 = 0; g1 < grif->GetLowGainMultiplicity(); ++g1) {
-         obj.FillHistogram("HitPatterns", "gHP_lg", 65, 0, 65, grif->GetGriffinLowGainHit(g1)->GetArrayNumber());
-         obj.FillHistogram("GRIFFIN", "gE_lg", 5000, 0, 5000, grif->GetGriffinLowGainHit(g1)->GetEnergy(), 65, 0, 65, grif->GetGriffinLowGainHit(g1)->GetArrayNumber());
-      }
-      for(auto g1 = 0; g1 < grif->GetHighGainMultiplicity(); ++g1) {
-         obj.FillHistogram("HitPatterns", "gHP_hg", 65, 0, 65, grif->GetGriffinHighGainHit(g1)->GetArrayNumber());
-         obj.FillHistogram("GRIFFIN", "gE_hg", 5000, 0, 5000, grif->GetGriffinHighGainHit(g1)->GetEnergy(), 65, 0, 65, grif->GetGriffinHighGainHit(g1)->GetArrayNumber());
+      for(auto g1 = 0; g1 < grif->GetMultiplicity(); ++g1) {
+         obj.FillHistogram("HitPatterns", "gHP", 65, 0, 65, grif->GetGriffinHit(g1)->GetArrayNumber());
+         obj.FillHistogram("GRIFFIN", "gE", 5000, 0, 5000, grif->GetGriffinHit(g1)->GetEnergy(), 65, 0, 65, grif->GetGriffinHit(g1)->GetArrayNumber());
       }
    }
 }

--- a/include/TGriffin.h
+++ b/include/TGriffin.h
@@ -23,17 +23,15 @@
 class TGriffin : public TSuppressed {
 public:
    enum class EGriffinBits {
-      kIsLowGainAddbackSet            = 1 << 0,
-      kIsHighGainAddbackSet           = 1 << 1,
-      kIsLowGainCrossTalkSet          = 1 << 2,
-      kIsHighGainCrossTalkSet         = 1 << 3,
-      kIsLowGainSuppressed            = 1 << 4,
-      kIsHighGainSuppressed           = 1 << 5,
-      kIsLowGainSuppressedAddbackSet  = 1 << 6,
-      kIsHighGainSuppressedAddbackSet = 1 << 7
+      kIsAddbackSet           = 1 << 0,
+      kSpare1                 = 1 << 1,
+      kIsCrossTalkSet         = 1 << 2,
+      kSpare3                 = 1 << 3,
+      kIsSuppressed           = 1 << 4,
+      kSpare5                 = 1 << 5,
+      kIsSuppressedAddbackSet = 1 << 6,
+      kSpare7                 = 1 << 7
    };
-   enum class EGainBits { kLowGain,
-                          kHighGain };
 
    TGriffin();
    TGriffin(const TGriffin&);
@@ -42,14 +40,7 @@ public:
    TGriffin& operator=(TGriffin&&) noexcept = default;
    ~TGriffin() override;
 
-   TGriffinHit* GetGriffinLowGainHit(const int& i);                                              //!<!
-   TGriffinHit* GetGriffinHighGainHit(const int& i);                                             //!<!
-   TGriffinHit* GetGriffinHit(const int& i) { return GetGriffinHit(i, GetDefaultGainType()); }   //!<!
-   using TDetector::GetHit;
-   TDetectorHit* GetHit(const int& idx);
-   Short_t       GetLowGainMultiplicity() const { return TDetector::GetMultiplicity(); }
-   Short_t       GetHighGainMultiplicity() const { return fGriffinHighGainHits.size(); }
-   Short_t       GetMultiplicity() const override { return GetMultiplicity(GetDefaultGainType()); }
+   TGriffinHit* GetGriffinHit(const int& i);   //!<!
 
    static TVector3    GetPosition(int DetNbr, int CryNbr = 5, double dist = 110.0);   //!<!
    static TVector3    GetDetectorPosition(int DetNbr);                                //!<!
@@ -63,9 +54,6 @@ public:
    {
       TDetector::ClearTransients();
       fGriffinBits = 0;
-      for(const auto& hit : fGriffinHighGainHits) {
-         hit->ClearTransients();
-      }
    }
    void ResetFlags() const;
 
@@ -79,19 +67,11 @@ public:
    bool AddbackCriterion(const TDetectorHit* hit1, const TDetectorHit* hit2) override { return fAddbackCriterion(hit1, hit2); }
 #endif
 
-   Short_t      GetAddbackLowGainMultiplicity();
-   Short_t      GetAddbackHighGainMultiplicity();
-   Short_t      GetAddbackMultiplicity() { return GetAddbackMultiplicity(GetDefaultGainType()); }
-   TGriffinHit* GetAddbackLowGainHit(const int& i);
-   TGriffinHit* GetAddbackHighGainHit(const int& i);
-   TGriffinHit* GetAddbackHit(const int& i) { return GetAddbackHit(i, GetDefaultGainType()); }
-   bool         IsAddbackSet(const EGainBits& gain_type) const;
-   void         ResetLowGainAddback();                                   //!<!
-   void         ResetHighGainAddback();                                  //!<!
-   void         ResetAddback() { ResetAddback(GetDefaultGainType()); }   //!<!
-   UShort_t     GetNHighGainAddbackFrags(const size_t& idx);
-   UShort_t     GetNLowGainAddbackFrags(const size_t& idx);
-   UShort_t     GetNAddbackFrags(const size_t& idx) { return GetNAddbackFrags(idx, GetDefaultGainType()); }
+   Short_t      GetAddbackMultiplicity();
+   TGriffinHit* GetAddbackHit(const int& i);
+   bool         IsAddbackSet() const;
+   void         ResetAddback();                                   //!<!
+   UShort_t     GetNAddbackFrags(const size_t& idx);
 
 #if !defined(__CINT__) && !defined(__CLING__)
    void SetSuppressionCriterion(std::function<bool(const TDetectorHit*, const TDetectorHit*)> criterion)
@@ -103,30 +83,16 @@ public:
    bool SuppressionCriterion(const TDetectorHit* hit, const TDetectorHit* bgoHit) override { return fSuppressionCriterion(hit, bgoHit); }
 #endif
 
-   TGriffinHit* GetSuppressedLowGainHit(const int& i);                                                 //!<!
-   TGriffinHit* GetSuppressedHighGainHit(const int& i);                                                //!<!
-   TGriffinHit* GetSuppressedHit(const int& i) { return GetSuppressedHit(i, GetDefaultGainType()); }   //!<!
-   Short_t      GetSuppressedLowGainMultiplicity(const TBgo* bgo);
-   Short_t      GetSuppressedHighGainMultiplicity(const TBgo* bgo);
-   Short_t      GetSuppressedMultiplicity(const TBgo* bgo) { return GetSuppressedMultiplicity(bgo, GetDefaultGainType()); }
-   bool         IsSuppressed(const EGainBits& gain_type) const;
-   void         ResetLowGainSuppressed();                                      //!<!
-   void         ResetHighGainSuppressed();                                     //!<!
-   void         ResetSuppressed() { ResetSuppressed(GetDefaultGainType()); }   //!<!
+   TGriffinHit* GetSuppressedHit(const int& i);   //!<!
+   Short_t      GetSuppressedMultiplicity(const TBgo* bgo);
+   bool         IsSuppressed() const;
+   void         ResetSuppressed();
 
-   Short_t      GetSuppressedAddbackLowGainMultiplicity(const TBgo* bgo);
-   Short_t      GetSuppressedAddbackHighGainMultiplicity(const TBgo* bgo);
-   Short_t      GetSuppressedAddbackMultiplicity(const TBgo* bgo) { return GetSuppressedAddbackMultiplicity(bgo, GetDefaultGainType()); }
-   TGriffinHit* GetSuppressedAddbackLowGainHit(const int& i);
-   TGriffinHit* GetSuppressedAddbackHighGainHit(const int& i);
-   TGriffinHit* GetSuppressedAddbackHit(const int& i) { return GetSuppressedAddbackHit(i, GetDefaultGainType()); }
-   bool         IsSuppressedAddbackSet(const EGainBits& gain_type) const;
-   void         ResetLowGainSuppressedAddback();                                             //!<!
-   void         ResetHighGainSuppressedAddback();                                            //!<!
-   void         ResetSuppressedAddback() { ResetSuppressedAddback(GetDefaultGainType()); }   //!<!
-   UShort_t     GetNHighGainSuppressedAddbackFrags(const size_t& idx);
-   UShort_t     GetNLowGainSuppressedAddbackFrags(const size_t& idx);
-   UShort_t     GetNSuppressedAddbackFrags(const size_t& idx) { return GetNSuppressedAddbackFrags(idx, GetDefaultGainType()); }
+   Short_t      GetSuppressedAddbackMultiplicity(const TBgo* bgo);
+   TGriffinHit* GetSuppressedAddbackHit(const int& i);
+   bool         IsSuppressedAddbackSet() const;
+   void         ResetSuppressedAddback();
+   UShort_t     GetNSuppressedAddbackFrags(const size_t& idx);
 
 private:
 #if !defined(__CINT__) && !defined(__CLING__)
@@ -134,35 +100,21 @@ private:
    static std::function<bool(const TDetectorHit*, const TDetectorHit*)> fSuppressionCriterion;
 #endif
 
-   std::vector<TDetectorHit*> fGriffinHighGainHits;   //  The set of crystal hits
-
-   // static bool fSetBGOHits;                //!<!  Flag that determines if BGOHits are being measured
-
    static bool fSetCoreWave;   //!<!  Flag for Waveforms ON/OFF
-   // static bool fSetBGOWave;                //!<!  Flag for BGO Waveforms ON/OFF
 
    int64_t                         fCycleStart;    //!<!  The start of the cycle
    mutable TTransientBits<UChar_t> fGriffinBits;   // Transient member flags
 
-   mutable std::vector<TDetectorHit*> fAddbackLowGainHits;     //!<! Used to create addback hits on the fly
-   mutable std::vector<TDetectorHit*> fAddbackHighGainHits;    //!<! Used to create addback hits on the fly
-   mutable std::vector<UShort_t>      fAddbackLowGainFrags;    //!<! Number of crystals involved in creating in the addback hit
-   mutable std::vector<UShort_t>      fAddbackHighGainFrags;   //!<! Number of crystals involved in creating in the addback hit
+   mutable std::vector<TDetectorHit*> fAddbackHits;     //!<! Used to create addback hits on the fly
+   mutable std::vector<UShort_t>      fAddbackFrags;    //!<! Number of crystals involved in creating in the addback hit
 
-   std::vector<TDetectorHit*> fSuppressedLowGainHits;    //!<!  The set of suppressed crystal hits
-   std::vector<TDetectorHit*> fSuppressedHighGainHits;   //!<!  The set of suppressed crystal hits
+   std::vector<TDetectorHit*> fSuppressedHits;    //!<!  The set of suppressed crystal hits
 
-   mutable std::vector<TDetectorHit*> fSuppressedAddbackLowGainHits;     //!<! Used to create suppressed addback hits on the fly
-   mutable std::vector<TDetectorHit*> fSuppressedAddbackHighGainHits;    //!<! Used to create suppressed addback hits on the fly
-   mutable std::vector<UShort_t>      fSuppressedAddbackLowGainFrags;    //!<! Number of crystals involved in creating in the suppressed addback hit
-   mutable std::vector<UShort_t>      fSuppressedAddbackHighGainFrags;   //!<! Number of crystals involved in creating in the suppressed addback hit
-
-   static EGainBits fDefaultGainType;
+   mutable std::vector<TDetectorHit*> fSuppressedAddbackHits;     //!<! Used to create suppressed addback hits on the fly
+   mutable std::vector<UShort_t>      fSuppressedAddbackFrags;    //!<! Number of crystals involved in creating in the suppressed addback hit
 
 public:
    static bool      SetCoreWave() { return fSetCoreWave; }   //!<!
-   static void      SetDefaultGainType(const EGainBits& gain_type);
-   static EGainBits GetDefaultGainType() { return fDefaultGainType; }
 
 private:
    static std::array<TVector3, 17> fCloverPosition;                            //!<! Position of each HPGe Clover
@@ -173,40 +125,16 @@ private:
    // Cross-Talk stuff
 public:
    static Double_t CTCorrectedEnergy(const TGriffinHit* hit_to_correct, const TGriffinHit* other_hit, bool time_constraint = true);
-   Bool_t          IsCrossTalkSet(const EGainBits& gain_type) const;
-   void            FixLowGainCrossTalk();
-   void            FixHighGainCrossTalk();
+   Bool_t          IsCrossTalkSet() const;
+   void            FixCrossTalk();
 
 private:
    // This is where the general untouchable functions live.
-   const std::vector<TDetectorHit*>& GetHitVector() const override { return GetHitVector(fDefaultGainType); }   //!<!
-   std::vector<TDetectorHit*>&       GetHitVector(const EGainBits& gain_type);                                  //!<!
-   const std::vector<TDetectorHit*>& GetHitVector(const EGainBits& gain_type) const;                            //!<!
-   std::vector<TDetectorHit*>&       GetAddbackVector(const EGainBits& gain_type);                              //!<!
-   std::vector<UShort_t>&            GetAddbackFragVector(const EGainBits& gain_type);                          //!<!
-   TGriffinHit*                      GetGriffinHit(const int& i, const EGainBits& gain_type);                   //!<!
-   Short_t                           GetMultiplicity(const EGainBits& gain_type) const;
-   TGriffinHit*                      GetAddbackHit(const int& i, const EGainBits& gain_type);
-   Short_t                           GetAddbackMultiplicity(const EGainBits& gain_type);
-   void                              SetAddback(const EGainBits& gain_type, bool flag = true) const;
-   void                              ResetAddback(const EGainBits& gain_type);   //!<!
-   UShort_t                          GetNAddbackFrags(const size_t& idx, const EGainBits& gain_type);
+   void SetAddback(bool flag = true) const;
+   void SetSuppressed(bool flag = true) const;
+   void SetSuppressedAddback(bool flag = true) const;
 
-   std::vector<TDetectorHit*>& GetSuppressedVector(const EGainBits& gain_type);              //!<!
-   std::vector<TDetectorHit*>& GetSuppressedAddbackVector(const EGainBits& gain_type);       //!<!
-   std::vector<UShort_t>&      GetSuppressedAddbackFragVector(const EGainBits& gain_type);   //!<!
-   TGriffinHit*                GetSuppressedHit(const int& i, const EGainBits& gain_type);   //!<!
-   Short_t                     GetSuppressedMultiplicity(const TBgo* bgo, const EGainBits& gain_type);
-   void                        SetSuppressed(const EGainBits& gain_type, bool flag = true) const;
-   void                        ResetSuppressed(const EGainBits& gain_type);   //!<!
-   TGriffinHit*                GetSuppressedAddbackHit(const int& i, const EGainBits& gain_type);
-   Short_t                     GetSuppressedAddbackMultiplicity(const TBgo* bgo, const EGainBits& gain_type);
-   void                        SetSuppressedAddback(const EGainBits& gain_type, bool flag = true) const;
-   void                        ResetSuppressedAddback(const EGainBits& gain_type);   //!<!
-   UShort_t                    GetNSuppressedAddbackFrags(const size_t& idx, const EGainBits& gain_type);
-
-   void FixCrossTalk(const EGainBits& gain_type);
-   void SetCrossTalk(const EGainBits& gain_type, bool flag = true) const;
+   void SetCrossTalk(bool flag = true) const;
 
 public:
    void Copy(TObject&) const override;              //!<!
@@ -215,7 +143,7 @@ public:
    void Print(std::ostream& out) const override;    //!<!
 
    /// \cond CLASSIMP
-   ClassDefOverride(TGriffin, 6)   // Griffin Physics structure // NOLINT(readability-else-after-return)
+   ClassDefOverride(TGriffin, 7)   // Griffin Physics structure // NOLINT(readability-else-after-return)
    /// \endcond
 };
 /*! @} */

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
@@ -40,7 +40,6 @@ bool DefaultGriffinSuppression(const TDetectorHit* hit, const TDetectorHit* bgoH
 std::function<bool(const TDetectorHit*, const TDetectorHit*)> TGriffin::fSuppressionCriterion = DefaultGriffinSuppression;
 
 bool                TGriffin::fSetCoreWave     = false;
-TGriffin::EGainBits TGriffin::fDefaultGainType = TGriffin::EGainBits::kLowGain;
 
 // This seems unnecessary, and why 17?;//  they are static members, and need
 //  to be defined outside the header
@@ -127,41 +126,23 @@ void TGriffin::Copy(TObject& rhs) const
    // Copy function.
    TSuppressed::Copy(rhs);
 
-   // no need to copy low gain, this is already taken care of by TDetector::Copy (called by TSuppressed::Copy)
-   static_cast<TGriffin&>(rhs).fGriffinHighGainHits.resize(fGriffinHighGainHits.size(), nullptr);
-   for(size_t i = 0; i < fGriffinHighGainHits.size(); ++i) {
-      static_cast<TGriffin&>(rhs).fGriffinHighGainHits[i] = new TGriffinHit(*static_cast<TGriffinHit*>(fGriffinHighGainHits[i]));
-   }
+   // no need to copy hits, this is already taken care of by TDetector::Copy (called by TSuppressed::Copy)
    // not copying addback or suppressed vectors
-   for(auto& hit : static_cast<TGriffin&>(rhs).fAddbackLowGainHits) {
+   for(auto& hit : static_cast<TGriffin&>(rhs).fAddbackHits) {
       delete hit;
    }
-   for(auto& hit : static_cast<TGriffin&>(rhs).fAddbackHighGainHits) {
+   for(auto& hit : static_cast<TGriffin&>(rhs).fSuppressedHits) {
       delete hit;
    }
-   for(auto& hit : static_cast<TGriffin&>(rhs).fSuppressedLowGainHits) {
-      delete hit;
-   }
-   for(auto& hit : static_cast<TGriffin&>(rhs).fSuppressedHighGainHits) {
-      delete hit;
-   }
-   for(auto& hit : static_cast<TGriffin&>(rhs).fSuppressedAddbackLowGainHits) {
-      delete hit;
-   }
-   for(auto& hit : static_cast<TGriffin&>(rhs).fSuppressedAddbackHighGainHits) {
+   for(auto& hit : static_cast<TGriffin&>(rhs).fSuppressedAddbackHits) {
       delete hit;
    }
    static_cast<TGriffin&>(rhs).fGriffinBits = 0;
-   static_cast<TGriffin&>(rhs).fAddbackLowGainHits.clear();
-   static_cast<TGriffin&>(rhs).fAddbackHighGainHits.clear();
-   static_cast<TGriffin&>(rhs).fAddbackLowGainFrags.clear();
-   static_cast<TGriffin&>(rhs).fAddbackHighGainFrags.clear();
-   static_cast<TGriffin&>(rhs).fSuppressedLowGainHits.clear();
-   static_cast<TGriffin&>(rhs).fSuppressedHighGainHits.clear();
-   static_cast<TGriffin&>(rhs).fSuppressedAddbackLowGainHits.clear();
-   static_cast<TGriffin&>(rhs).fSuppressedAddbackHighGainHits.clear();
-   static_cast<TGriffin&>(rhs).fSuppressedAddbackLowGainFrags.clear();
-   static_cast<TGriffin&>(rhs).fSuppressedAddbackHighGainFrags.clear();
+   static_cast<TGriffin&>(rhs).fAddbackHits.clear();
+   static_cast<TGriffin&>(rhs).fAddbackFrags.clear();
+   static_cast<TGriffin&>(rhs).fSuppressedHits.clear();
+   static_cast<TGriffin&>(rhs).fSuppressedAddbackHits.clear();
+   static_cast<TGriffin&>(rhs).fSuppressedAddbackFrags.clear();
 
    static_cast<TGriffin&>(rhs).fCycleStart = fCycleStart;
 }
@@ -169,26 +150,14 @@ void TGriffin::Copy(TObject& rhs) const
 TGriffin::~TGriffin()
 {
    // Default Destructor
-   // no need to delete low gain hits, this is taken care of by the destructor of TDetector
-   for(auto& hit : fGriffinHighGainHits) {
+   // no need to delete hits, this is taken care of by the destructor of TDetector
+   for(auto& hit : fAddbackHits) {
       delete hit;
    }
-   for(auto& hit : fAddbackLowGainHits) {
+   for(auto& hit : fSuppressedHits) {
       delete hit;
    }
-   for(auto& hit : fAddbackHighGainHits) {
-      delete hit;
-   }
-   for(auto& hit : fSuppressedLowGainHits) {
-      delete hit;
-   }
-   for(auto& hit : fSuppressedHighGainHits) {
-      delete hit;
-   }
-   for(auto& hit : fSuppressedAddbackLowGainHits) {
-      delete hit;
-   }
-   for(auto& hit : fSuppressedAddbackHighGainHits) {
+   for(auto& hit : fSuppressedAddbackHits) {
       delete hit;
    }
 }
@@ -198,39 +167,21 @@ void TGriffin::Clear(Option_t* opt)
    // Clears the mother, and all of the hits
    ClearStatus();
    TSuppressed::Clear(opt);
-   // low gain hits cleared by TDetector::Clear
-   for(auto& hit : fGriffinHighGainHits) {
+   // hits cleared by TDetector::Clear
+   for(auto& hit : fAddbackHits) {
       delete hit;
    }
-   for(auto& hit : fAddbackLowGainHits) {
+   for(auto& hit : fSuppressedHits) {
       delete hit;
    }
-   for(auto& hit : fAddbackHighGainHits) {
+   for(auto& hit : fSuppressedAddbackHits) {
       delete hit;
    }
-   for(auto& hit : fSuppressedLowGainHits) {
-      delete hit;
-   }
-   for(auto& hit : fSuppressedHighGainHits) {
-      delete hit;
-   }
-   for(auto& hit : fSuppressedAddbackLowGainHits) {
-      delete hit;
-   }
-   for(auto& hit : fSuppressedAddbackHighGainHits) {
-      delete hit;
-   }
-   fGriffinHighGainHits.clear();
-   fAddbackLowGainHits.clear();
-   fAddbackHighGainHits.clear();
-   fAddbackLowGainFrags.clear();
-   fAddbackHighGainFrags.clear();
-   fSuppressedLowGainHits.clear();
-   fSuppressedHighGainHits.clear();
-   fSuppressedAddbackLowGainHits.clear();
-   fSuppressedAddbackHighGainHits.clear();
-   fSuppressedAddbackLowGainFrags.clear();
-   fSuppressedAddbackHighGainFrags.clear();
+   fAddbackHits.clear();
+   fAddbackFrags.clear();
+   fSuppressedHits.clear();
+   fSuppressedAddbackHits.clear();
+   fSuppressedAddbackFrags.clear();
 
    fCycleStart = 0;
 }
@@ -244,36 +195,22 @@ void TGriffin::Print(std::ostream& out) const
 {
    std::ostringstream str;
    str << "Griffin Contains: " << std::endl;
-   str << std::setw(6) << GetLowGainMultiplicity() << " Low gain hits" << std::endl;
+   str << std::setw(6) << GetMultiplicity() << " hits" << std::endl;
    //if(TString(opt).Contains("all", TString::ECaseCompare::kIgnoreCase)) {
    for(const auto& hit : Hits()) {
       static_cast<TGriffinHit*>(hit)->Print(str);
    }
    //}
-   str << std::setw(6) << GetHighGainMultiplicity() << " High gain hits" << std::endl;
-   //if(TString(opt).Contains("all", TString::ECaseCompare::kIgnoreCase)) {
-   for(const auto& hit : fGriffinHighGainHits) {
-      static_cast<TGriffinHit*>(hit)->Print(str);
-   }
-   //}
 
-   if(IsAddbackSet(EGainBits::kLowGain)) {
-      str << std::setw(6) << fAddbackLowGainHits.size() << " Low gain addback hits" << std::endl;
+   if(IsAddbackSet()) {
+      str << std::setw(6) << fAddbackHits.size() << " addback hits" << std::endl;
    } else {
       str << std::setw(6) << " "
-          << " Low Gain Addback not set" << std::endl;
-   }
-
-   if(IsAddbackSet(EGainBits::kHighGain)) {
-      str << std::setw(6) << fAddbackHighGainHits.size() << " High gain addback hits" << std::endl;
-   } else {
-      str << std::setw(6) << " "
-          << " High Gain Addback not set" << std::endl;
+          << " Addback not set" << std::endl;
    }
 
    str << std::setw(6) << " "
-       << " Cross-talk Set?  Low gain: " << IsCrossTalkSet(EGainBits::kLowGain)
-       << "   High gain: " << IsCrossTalkSet(EGainBits::kHighGain) << std::endl;
+       << " Cross-talk Set? " << IsCrossTalkSet() << std::endl;
    str << std::setw(6) << fCycleStart << " cycle start" << std::endl;
    out << str.str();
 }
@@ -284,116 +221,38 @@ TGriffin& TGriffin::operator=(const TGriffin& rhs)
    return *this;
 }
 
-void TGriffin::SetDefaultGainType(const EGainBits& gain_type)
+bool TGriffin::IsAddbackSet() const
 {
-   if((gain_type == EGainBits::kLowGain) || (gain_type == EGainBits::kHighGain)) {
-      fDefaultGainType = gain_type;
-   } else {
-      std::cerr << static_cast<std::underlying_type<EGainBits>::type>(gain_type) << " is not a known gain type. Please use kLowGain or kHighGain" << std::endl;
-   }
+   return TestBitNumber(EGriffinBits::kIsAddbackSet);
 }
 
-Short_t TGriffin::GetMultiplicity(const EGainBits& gain_type) const
+bool TGriffin::IsCrossTalkSet() const
 {
-   switch(gain_type) {
-   case EGainBits::kLowGain: return TDetector::GetMultiplicity();
-   case EGainBits::kHighGain: return fGriffinHighGainHits.size();
-   };
-   return 0;
+   return TestBitNumber(EGriffinBits::kIsCrossTalkSet);
 }
 
-const std::vector<TDetectorHit*>& TGriffin::GetHitVector(const EGainBits& gain_type) const
+void TGriffin::SetAddback(const bool flag) const
 {
-   switch(gain_type) {
-   case EGainBits::kLowGain: return Hits();
-   case EGainBits::kHighGain: return fGriffinHighGainHits;
-   };
-   return Hits();
+   return SetBitNumber(EGriffinBits::kIsAddbackSet, flag);
 }
 
-std::vector<TDetectorHit*>& TGriffin::GetHitVector(const EGainBits& gain_type)
+void TGriffin::SetCrossTalk(const bool flag) const
 {
-   switch(gain_type) {
-   case EGainBits::kLowGain: return Hits();
-   case EGainBits::kHighGain: return fGriffinHighGainHits;
-   };
-   return Hits();
+   return SetBitNumber(EGriffinBits::kIsCrossTalkSet, flag);
 }
 
-std::vector<TDetectorHit*>& TGriffin::GetAddbackVector(const EGainBits& gain_type)
+TGriffinHit* TGriffin::GetGriffinHit(const int& i)
 {
-   switch(gain_type) {
-   case EGainBits::kLowGain: return fAddbackLowGainHits;
-   case EGainBits::kHighGain: return fAddbackHighGainHits;
-   };
-   return fAddbackLowGainHits;
-}
-
-std::vector<UShort_t>& TGriffin::GetAddbackFragVector(const EGainBits& gain_type)
-{
-   switch(gain_type) {
-   case EGainBits::kLowGain: return fAddbackLowGainFrags;
-   case EGainBits::kHighGain: return fAddbackHighGainFrags;
-   };
-   return fAddbackLowGainFrags;
-}
-
-bool TGriffin::IsAddbackSet(const EGainBits& gain_type) const
-{
-   switch(gain_type) {
-   case EGainBits::kLowGain: return TestBitNumber(EGriffinBits::kIsLowGainAddbackSet);
-   case EGainBits::kHighGain: return TestBitNumber(EGriffinBits::kIsHighGainAddbackSet);
-   };
-   return false;
-}
-
-bool TGriffin::IsCrossTalkSet(const EGainBits& gain_type) const
-{
-   switch(gain_type) {
-   case EGainBits::kLowGain: return TestBitNumber(EGriffinBits::kIsLowGainCrossTalkSet);
-   case EGainBits::kHighGain: return TestBitNumber(EGriffinBits::kIsHighGainCrossTalkSet);
-   };
-   return false;
-}
-
-void TGriffin::SetAddback(const EGainBits& gain_type, const bool flag) const
-{
-   switch(gain_type) {
-   case EGainBits::kLowGain: return SetBitNumber(EGriffinBits::kIsLowGainAddbackSet, flag);
-   case EGainBits::kHighGain: return SetBitNumber(EGriffinBits::kIsHighGainAddbackSet, flag);
-   };
-}
-
-void TGriffin::SetCrossTalk(const EGainBits& gain_type, const bool flag) const
-{
-   switch(gain_type) {
-   case EGainBits::kLowGain: return SetBitNumber(EGriffinBits::kIsLowGainCrossTalkSet, flag);
-   case EGainBits::kHighGain: return SetBitNumber(EGriffinBits::kIsHighGainCrossTalkSet, flag);
-   };
-}
-
-TDetectorHit* TGriffin::GetHit(const int& idx)
-{
-   return GetGriffinHit(idx);
-}
-
-TGriffinHit* TGriffin::GetGriffinLowGainHit(const int& i)
-{
-   return GetGriffinHit(i, EGainBits::kLowGain);
-}
-
-TGriffinHit* TGriffin::GetGriffinHighGainHit(const int& i)
-{
-   return GetGriffinHit(i, EGainBits::kHighGain);
-}
-
-TGriffinHit* TGriffin::GetGriffinHit(const int& i, const EGainBits& gain_type)
-{
+	/// Get Griffin hit indicated by index i.
+	/// Throws an out of range exception if the index is out of the range of the hit vector.
+	/// Applies cross-talk corrections if they haven't already been applied and are enabled.
+	/// Note: This is different from using TDetector::GetHit and casting the result to a `TGriffinHit*`
+	/// as in that case no cross-talk corrections are applied.
    try {
-      if(!IsCrossTalkSet(gain_type)) {
-         FixCrossTalk(gain_type);
+      if(!IsCrossTalkSet()) {
+         FixCrossTalk();
       }
-      return static_cast<TGriffinHit*>(GetHitVector(gain_type).at(i));
+      return static_cast<TGriffinHit*>(Hits().at(i));
    } catch(const std::out_of_range& oor) {
       std::cerr << ClassName() << " Hits are out of range: " << oor.what() << std::endl;
       if(!gInterpreter) {
@@ -403,60 +262,38 @@ TGriffinHit* TGriffin::GetGriffinHit(const int& i, const EGainBits& gain_type)
    return nullptr;
 }
 
-Short_t TGriffin::GetAddbackLowGainMultiplicity()
-{
-   return GetAddbackMultiplicity(EGainBits::kLowGain);
-}
-
-Short_t TGriffin::GetAddbackHighGainMultiplicity()
-{
-   return GetAddbackMultiplicity(EGainBits::kHighGain);
-}
-
-Short_t TGriffin::GetAddbackMultiplicity(const EGainBits& gain_type)
+Short_t TGriffin::GetAddbackMultiplicity()
 {
    // Automatically builds the addback hits using the fAddbackCriterion (if the size of the fAddbackHits vector is zero)
    // and return the number of addback hits.
-   if(!IsCrossTalkSet(gain_type)) {
+   if(!IsCrossTalkSet()) {
       // Calculate Cross Talk on each hit
-      FixCrossTalk(gain_type);
+      FixCrossTalk();
    }
-   auto& hit_vec  = GetHitVector(gain_type);
-   auto& ab_vec   = GetAddbackVector(gain_type);
-   auto& frag_vec = GetAddbackFragVector(gain_type);
-   if(hit_vec.empty()) {
+   auto& hitVector  = Hits();
+   if(hitVector.empty()) {
       return 0;
    }
    // if the addback has been reset, clear the addback hits
-   if(!IsAddbackSet(gain_type)) {
-      for(auto& hit : ab_vec) {
+   if(!IsAddbackSet()) {
+      for(auto& hit : fAddbackHits) {
          delete hit;
       }
-      ab_vec.clear();
-      frag_vec.clear();
+      fAddbackHits.clear();
+      fAddbackFrags.clear();
    }
-   if(ab_vec.empty()) {
-      CreateAddback(hit_vec, ab_vec, frag_vec);
-      SetAddback(gain_type, true);
+   if(fAddbackHits.empty()) {
+      CreateAddback(hitVector, fAddbackHits, fAddbackFrags);
+      SetAddback(true);
    }
 
-   return ab_vec.size();
+   return fAddbackHits.size();
 }
 
-TGriffinHit* TGriffin::GetAddbackLowGainHit(const int& i)
+TGriffinHit* TGriffin::GetAddbackHit(const int& i)
 {
-   return GetAddbackHit(i, EGainBits::kLowGain);
-}
-
-TGriffinHit* TGriffin::GetAddbackHighGainHit(const int& i)
-{
-   return GetAddbackHit(i, EGainBits::kHighGain);
-}
-
-TGriffinHit* TGriffin::GetAddbackHit(const int& i, const EGainBits& gain_type)
-{
-   if(i < GetAddbackMultiplicity(gain_type)) {
-      return static_cast<TGriffinHit*>(GetAddbackVector(gain_type)[i]);
+   if(i < GetAddbackMultiplicity()) {
+      return static_cast<TGriffinHit*>(fAddbackHits[i]);
    }
    std::cerr << "Addback hits are out of range" << std::endl;
    throw grsi::exit_exception(1);
@@ -482,16 +319,14 @@ void TGriffin::AddFragment(const std::shared_ptr<const TFragment>& frag, TChanne
       return;
    }
 
-   // only create the hit if we have a HPGe signal (A or B), not a suppressor (S)
+   // only create the hit if we have a HPGe signal (A), not a suppressor (S) or backup HPGe signal (B)
    switch(mnemonic->OutputSensor()) {
    case TMnemonic::EMnemonic::kA: {
       auto* hit = new TGriffinHit(*frag);
-      GetHitVector(EGainBits::kLowGain).push_back(hit);
+      Hits().push_back(hit);
    } break;
-   case TMnemonic::EMnemonic::kB: {
-      auto* hit = new TGriffinHit(*frag);
-      GetHitVector(EGainBits::kHighGain).push_back(hit);
-   } break;
+	case TMnemonic::EMnemonic::kB:
+	   break;
    default:
       std::cout << "output sensor " << static_cast<std::underlying_type<TMnemonic::EMnemonic>::type>(mnemonic->OutputSensor()) << ", skipping it" << std::endl;
       break;
@@ -545,43 +380,23 @@ void TGriffin::ResetFlags() const
    fGriffinBits = 0;
 }
 
-void TGriffin::ResetLowGainAddback()
+void TGriffin::ResetAddback()
 {
-   ResetAddback(EGainBits::kLowGain);
-}
-
-void TGriffin::ResetHighGainAddback()
-{
-   ResetAddback(EGainBits::kLowGain);
-}
-
-void TGriffin::ResetAddback(const EGainBits& gain_type)
-{
-   SetAddback(gain_type, false);
-   SetCrossTalk(gain_type, false);
-   for(auto& hit : GetAddbackVector(gain_type)) {
+   SetAddback(false);
+   SetCrossTalk(false);
+   for(auto& hit : fAddbackHits) {
       delete hit;
    }
-   GetAddbackVector(gain_type).clear();
-   GetAddbackFragVector(gain_type).clear();
+   fAddbackHits.clear();
+   fAddbackFrags.clear();
 }
 
-UShort_t TGriffin::GetNLowGainAddbackFrags(const size_t& idx)
-{
-   return GetNAddbackFrags(idx, EGainBits::kLowGain);
-}
-
-UShort_t TGriffin::GetNHighGainAddbackFrags(const size_t& idx)
-{
-   return GetNAddbackFrags(idx, EGainBits::kHighGain);
-}
-
-UShort_t TGriffin::GetNAddbackFrags(const size_t& idx, const EGainBits& gain_type)
+UShort_t TGriffin::GetNAddbackFrags(const size_t& idx)
 {
    // Get the number of addback "fragments" contributing to the total addback hit
    // with index idx.
-   if(idx < GetAddbackFragVector(gain_type).size()) {
-      return GetAddbackFragVector(gain_type)[idx];
+   if(idx < fAddbackFrags.size()) {
+      return fAddbackFrags[idx];
    }
    return 0;
 }
@@ -630,35 +445,25 @@ Double_t TGriffin::CTCorrectedEnergy(const TGriffinHit* const hit_to_correct, co
    return fixed_energy;
 }
 
-void TGriffin::FixLowGainCrossTalk()
-{
-   FixCrossTalk(EGainBits::kLowGain);
-}
-
-void TGriffin::FixHighGainCrossTalk()
-{
-   FixCrossTalk(EGainBits::kHighGain);
-}
-
-void TGriffin::FixCrossTalk(const EGainBits& gain_type)
+void TGriffin::FixCrossTalk()
 {
    if(!TGRSIOptions::AnalysisOptions()->IsCorrectingCrossTalk()) { return; }
 
-   auto& hit_vec = GetHitVector(gain_type);
-   if(hit_vec.size() < 2) {
-      SetCrossTalk(gain_type, true);
+   auto& hitVector = Hits();
+   if(hitVector.size() < 2) {
+      SetCrossTalk(true);
       return;
    }
-   for(auto& hit : hit_vec) {
+   for(auto& hit : hitVector) {
       static_cast<TGriffinHit*>(hit)->ClearEnergy();
    }
 
-   for(auto& one : hit_vec) {
-      for(auto& two : hit_vec) {
+   for(auto& one : hitVector) {
+      for(auto& two : hitVector) {
          one->SetEnergy(CTCorrectedEnergy(static_cast<TGriffinHit*>(one), static_cast<TGriffinHit*>(two)));
       }
    }
-   SetCrossTalk(gain_type, true);
+   SetCrossTalk(true);
 }
 
 const char* TGriffin::GetColorFromNumber(int number)
@@ -672,128 +477,23 @@ const char* TGriffin::GetColorFromNumber(int number)
    return "X";
 }
 
-TGriffinHit* TGriffin::GetSuppressedLowGainHit(const int& i)
+bool TGriffin::IsSuppressed() const
 {
-   return GetSuppressedHit(i, EGainBits::kLowGain);
+   return TestBitNumber(EGriffinBits::kIsSuppressed);
 }
 
-TGriffinHit* TGriffin::GetSuppressedHighGainHit(const int& i)
+bool TGriffin::IsSuppressedAddbackSet() const
 {
-   return GetSuppressedHit(i, EGainBits::kHighGain);
+   return TestBitNumber(EGriffinBits::kIsSuppressedAddbackSet);
 }
 
-Short_t TGriffin::GetSuppressedLowGainMultiplicity(const TBgo* bgo)
-{
-   return GetSuppressedMultiplicity(bgo, EGainBits::kLowGain);
-}
-
-Short_t TGriffin::GetSuppressedHighGainMultiplicity(const TBgo* bgo)
-{
-   return GetSuppressedMultiplicity(bgo, EGainBits::kHighGain);
-}
-
-bool TGriffin::IsSuppressed(const EGainBits& gain_type) const
-{
-   switch(gain_type) {
-   case EGainBits::kLowGain: return TestBitNumber(EGriffinBits::kIsLowGainSuppressed);
-   case EGainBits::kHighGain: return TestBitNumber(EGriffinBits::kIsHighGainSuppressed);
-   };
-   return false;
-}
-
-void TGriffin::ResetLowGainSuppressed()
-{
-   ResetSuppressed(EGainBits::kLowGain);
-}
-
-void TGriffin::ResetHighGainSuppressed()
-{
-   ResetSuppressed(EGainBits::kHighGain);
-}
-
-Short_t TGriffin::GetSuppressedAddbackLowGainMultiplicity(const TBgo* bgo)
-{
-   return GetSuppressedAddbackMultiplicity(bgo, EGainBits::kLowGain);
-}
-
-Short_t TGriffin::GetSuppressedAddbackHighGainMultiplicity(const TBgo* bgo)
-{
-   return GetSuppressedAddbackMultiplicity(bgo, EGainBits::kHighGain);
-}
-
-TGriffinHit* TGriffin::GetSuppressedAddbackLowGainHit(const int& i)
-{
-   return GetSuppressedAddbackHit(i, EGainBits::kLowGain);
-}
-
-TGriffinHit* TGriffin::GetSuppressedAddbackHighGainHit(const int& i)
-{
-   return GetSuppressedAddbackHit(i, EGainBits::kHighGain);
-}
-
-bool TGriffin::IsSuppressedAddbackSet(const EGainBits& gain_type) const
-{
-   switch(gain_type) {
-   case EGainBits::kLowGain: return TestBitNumber(EGriffinBits::kIsLowGainSuppressedAddbackSet);
-   case EGainBits::kHighGain: return TestBitNumber(EGriffinBits::kIsHighGainSuppressedAddbackSet);
-   };
-   return false;
-}
-
-void TGriffin::ResetLowGainSuppressedAddback()
-{
-   ResetSuppressedAddback(EGainBits::kLowGain);
-}
-
-void TGriffin::ResetHighGainSuppressedAddback()
-{
-   ResetSuppressedAddback(EGainBits::kHighGain);
-}
-
-UShort_t TGriffin::GetNLowGainSuppressedAddbackFrags(const size_t& idx)
-{
-   return GetNSuppressedAddbackFrags(idx, EGainBits::kLowGain);
-}
-
-UShort_t TGriffin::GetNHighGainSuppressedAddbackFrags(const size_t& idx)
-{
-   return GetNSuppressedAddbackFrags(idx, EGainBits::kHighGain);
-}
-
-std::vector<TDetectorHit*>& TGriffin::GetSuppressedVector(const EGainBits& gain_type)
-{
-   switch(gain_type) {
-   case EGainBits::kLowGain: return fSuppressedLowGainHits;
-   case EGainBits::kHighGain: return fSuppressedHighGainHits;
-   };
-   return fSuppressedLowGainHits;
-}
-
-std::vector<TDetectorHit*>& TGriffin::GetSuppressedAddbackVector(const EGainBits& gain_type)
-{
-   switch(gain_type) {
-   case EGainBits::kLowGain: return fSuppressedAddbackLowGainHits;
-   case EGainBits::kHighGain: return fSuppressedAddbackHighGainHits;
-   };
-   return fSuppressedAddbackLowGainHits;
-}
-
-std::vector<UShort_t>& TGriffin::GetSuppressedAddbackFragVector(const EGainBits& gain_type)
-{
-   switch(gain_type) {
-   case EGainBits::kLowGain: return fSuppressedAddbackLowGainFrags;
-   case EGainBits::kHighGain: return fSuppressedAddbackHighGainFrags;
-   };
-   return fSuppressedAddbackLowGainFrags;
-}
-
-TGriffinHit* TGriffin::GetSuppressedHit(const int& i, const EGainBits& gain_type)
+TGriffinHit* TGriffin::GetSuppressedHit(const int& i)
 {
    try {
-      if(!IsCrossTalkSet(gain_type)) {
-         FixCrossTalk(gain_type);
+      if(!IsCrossTalkSet()) {
+         FixCrossTalk();
       }
-      return static_cast<TGriffinHit*>(GetSuppressedVector(gain_type).at(i));
+      return static_cast<TGriffinHit*>(fSuppressedHits.at(i));
    } catch(const std::out_of_range& oor) {
       std::cerr << ClassName() << " Suppressed hits are out of range: " << oor.what() << std::endl;
       if(!gInterpreter) {
@@ -803,58 +503,53 @@ TGriffinHit* TGriffin::GetSuppressedHit(const int& i, const EGainBits& gain_type
    return nullptr;
 }
 
-Short_t TGriffin::GetSuppressedMultiplicity(const TBgo* bgo, const EGainBits& gain_type)
+Short_t TGriffin::GetSuppressedMultiplicity(const TBgo* bgo)
 {
    /// Automatically builds the suppressed hits using the fSuppressionCriterion and returns the number of suppressed hits
-   if(!IsCrossTalkSet(gain_type)) {
+   if(!IsCrossTalkSet()) {
       // Calculate Cross Talk on each hit
-      FixCrossTalk(gain_type);
+      FixCrossTalk();
    }
-   auto& hit_vec = GetHitVector(gain_type);
-   auto& sup_vec = GetSuppressedVector(gain_type);
-   if(hit_vec.empty()) {
+   auto& hitVector = Hits();
+   if(hitVector.empty()) {
       return 0;
    }
    // if the suppressed has been reset, clear the suppressed hits
-   if(!IsSuppressed(gain_type)) {
-      for(auto& hit : sup_vec) {
+   if(!IsSuppressed()) {
+      for(auto& hit : fSuppressedHits) {
          delete hit;
       }
-      sup_vec.clear();
+      fSuppressedHits.clear();
    }
-   if(sup_vec.empty()) {
-      CreateSuppressed(bgo, hit_vec, sup_vec);
-      SetSuppressed(gain_type, true);
+   if(fSuppressedHits.empty()) {
+      CreateSuppressed(bgo, hitVector, fSuppressedHits);
+      SetSuppressed(true);
    }
 
-   return sup_vec.size();
+   return fSuppressedHits.size();
 }
 
-void TGriffin::SetSuppressed(const EGainBits& gain_type, const bool flag) const
+void TGriffin::SetSuppressed(const bool flag) const
 {
-   switch(gain_type) {
-   case EGainBits::kLowGain: return SetBitNumber(EGriffinBits::kIsLowGainSuppressed, flag);
-   case EGainBits::kHighGain: return SetBitNumber(EGriffinBits::kIsHighGainSuppressed, flag);
-   };
+   return SetBitNumber(EGriffinBits::kIsSuppressed, flag);
 }
 
-void TGriffin::ResetSuppressed(const EGainBits& gain_type)
+void TGriffin::ResetSuppressed()
 {
-   SetSuppressed(gain_type, false);
-   //SetCrossTalk(gain_type, false);
-   for(auto& hit : GetSuppressedVector(gain_type)) {
+   SetSuppressed(false);
+   for(auto& hit : fSuppressedHits) {
       delete hit;
    }
-   GetSuppressedVector(gain_type).clear();
+   fSuppressedHits.clear();
 }
 
-TGriffinHit* TGriffin::GetSuppressedAddbackHit(const int& i, const EGainBits& gain_type)
+TGriffinHit* TGriffin::GetSuppressedAddbackHit(const int& i)
 {
    try {
-      if(!IsCrossTalkSet(gain_type)) {
-         FixCrossTalk(gain_type);
+      if(!IsCrossTalkSet()) {
+         FixCrossTalk();
       }
-      return static_cast<TGriffinHit*>(GetSuppressedAddbackVector(gain_type).at(i));
+      return static_cast<TGriffinHit*>(fSuppressedAddbackHits.at(i));
    } catch(const std::out_of_range& oor) {
       std::cerr << ClassName() << " Suppressed addback hits are out of range: " << oor.what() << std::endl;
       if(!gInterpreter) {
@@ -864,59 +559,53 @@ TGriffinHit* TGriffin::GetSuppressedAddbackHit(const int& i, const EGainBits& ga
    return nullptr;
 }
 
-Short_t TGriffin::GetSuppressedAddbackMultiplicity(const TBgo* bgo, const EGainBits& gain_type)
+Short_t TGriffin::GetSuppressedAddbackMultiplicity(const TBgo* bgo)
 {
    /// Automatically builds the suppressed addback hits using the fAddbackCriterion (if the size of the fAddbackHits vector is zero)
    /// and return the number of suppressed addback hits.
-   if(!IsCrossTalkSet(gain_type)) {
+   if(!IsCrossTalkSet()) {
       // Calculate Cross Talk on each hit
-      FixCrossTalk(gain_type);
+      FixCrossTalk();
    }
-   auto& hit_vec  = GetHitVector(gain_type);
-   auto& ab_vec   = GetSuppressedAddbackVector(gain_type);
-   auto& frag_vec = GetSuppressedAddbackFragVector(gain_type);
-   if(hit_vec.empty()) {
+   auto& hitVector  = Hits();
+   if(hitVector.empty()) {
       return 0;
    }
    // if the addback has been reset, clear the addback hits
-   if(!IsSuppressedAddbackSet(gain_type)) {
-      for(auto& hit : ab_vec) {
+   if(!IsSuppressedAddbackSet()) {
+      for(auto& hit : fSuppressedAddbackHits) {
          delete hit;
       }
-      ab_vec.clear();
-      frag_vec.clear();
+      fSuppressedAddbackHits.clear();
+      fSuppressedAddbackFrags.clear();
    }
-   if(ab_vec.empty()) {
-      CreateSuppressedAddback(bgo, hit_vec, ab_vec, frag_vec);
-      SetSuppressedAddback(gain_type, true);
+   if(fSuppressedAddbackHits.empty()) {
+      CreateSuppressedAddback(bgo, hitVector, fSuppressedAddbackHits, fSuppressedAddbackFrags);
+      SetSuppressedAddback(true);
    }
 
-   return ab_vec.size();
+   return fSuppressedAddbackHits.size();
 }
 
-void TGriffin::SetSuppressedAddback(const EGainBits& gain_type, const bool flag) const
+void TGriffin::SetSuppressedAddback(const bool flag) const
 {
-   switch(gain_type) {
-   case EGainBits::kLowGain: return SetBitNumber(EGriffinBits::kIsLowGainSuppressedAddbackSet, flag);
-   case EGainBits::kHighGain: return SetBitNumber(EGriffinBits::kIsHighGainSuppressedAddbackSet, flag);
-   };
+   return SetBitNumber(EGriffinBits::kIsSuppressedAddbackSet, flag);
 }
 
-void TGriffin::ResetSuppressedAddback(const EGainBits& gain_type)
+void TGriffin::ResetSuppressedAddback()
 {
-   SetSuppressedAddback(gain_type, false);
-   //SetCrossTalk(gain_type, false);
-   for(auto& hit : GetSuppressedAddbackVector(gain_type)) {
+   SetSuppressedAddback(false);
+   for(auto& hit : fSuppressedAddbackHits) {
       delete hit;
    }
-   GetSuppressedAddbackVector(gain_type).clear();
-   GetSuppressedAddbackFragVector(gain_type).clear();
+   fSuppressedAddbackHits.clear();
+   fSuppressedAddbackFrags.clear();
 }
 
-UShort_t TGriffin::GetNSuppressedAddbackFrags(const size_t& idx, const EGainBits& gain_type)
+UShort_t TGriffin::GetNSuppressedAddbackFrags(const size_t& idx)
 {
    try {
-      return GetSuppressedAddbackFragVector(gain_type).at(idx);
+      return fSuppressedAddbackFrags.at(idx);
    } catch(const std::out_of_range& oor) {
       std::cerr << ClassName() << " Suppressed addback frags are out of range: " << oor.what() << std::endl;
       if(!gInterpreter) {

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
@@ -128,7 +128,7 @@ void TGriffin::Copy(TObject& rhs) const
    TSuppressed::Copy(rhs);
 
    // no need to copy low gain, this is already taken care of by TDetector::Copy (called by TSuppressed::Copy)
-   static_cast<TGriffin&>(rhs).fGriffinHighGainHits.resize(fGriffinHighGainHits.size());
+   static_cast<TGriffin&>(rhs).fGriffinHighGainHits.resize(fGriffinHighGainHits.size(), nullptr);
    for(size_t i = 0; i < fGriffinHighGainHits.size(); ++i) {
       static_cast<TGriffin&>(rhs).fGriffinHighGainHits[i] = new TGriffinHit(*static_cast<TGriffinHit*>(fGriffinHighGainHits[i]));
    }


### PR DESCRIPTION
For some reason the high gain hits started giving segmentation faults (see GRIFFINCollaboration/GRSISort#1501 and GRIFFINCollaboration/GRSISort#1509).

Since we don't use high and low gains anymore (and only ever have for a very short period of time), I've removed them. Now only the `A` channels are being used, but which electronics channel this corresponds to is entirely determined by the cal-file. So if someone really wanted to look at the alternative channels, the addresses could simply be swapped for those of the other channels and re-sorted.