### PR TITLE
Fix TIGRESS BGOs not being added to the analysis tree.

### DIFF
--- a/include/TTigress.h
+++ b/include/TTigress.h
@@ -58,6 +58,7 @@ public:
    static TVector3 GetPosition(int DetNbr, int CryNbr, int SegNbr, double dist = 0., bool smear = false);   //!<!
    static TVector3 GetPosition(const TTigressHit&, double dist = 0., bool smear = false);                   //!<!
 
+   std::vector<TBgoHit>       fBgos;
    void     AddBGO(TBgoHit& bgo) { fBgos.push_back(bgo); }        //!<!
    Short_t  GetBGOMultiplicity() const { return fBgos.size(); }   //!<!
    int      GetNBGOs() const { return fBgos.size(); }             //!<!
@@ -129,7 +130,6 @@ private:
 
    std::vector<TDetectorHit*> fAddbackHits;    //!<! Used to create addback hits on the fly
    std::vector<UShort_t>      fAddbackFrags;   //!<! Number of crystals involved in creating in the addback hit
-   std::vector<TBgoHit>       fBgos;
 
    static void BuildVectors();   //!<!
 


### PR DESCRIPTION
This is a separate issue from the TIGRESS addback stuff (GRIFFINCollaboration/GRSISort#1527). As of mid-2024, it seems that TIGRESS BGO hits are not added to the analysis tree (most TIGRESS people are still on older versions of GRSISort, so I guess no one noticed). I tracked the issue down to commit df3b0d95aad0c2dd2518f42e6d201970183bb7a3, where the `fBgos` member was changed from public to private. I have no idea why that breaks the BGO hits (I am but a humble procedural programmer who tries to avoid OOP at all costs), but this PR reverts the change to 'fix' the issue.

In GRIFFINCollaboration/GRSISort#1527 you had suggested to rewrite the TIGRESS classes to closer resemble the GRIFFIN ones, for maintainability. I have no problem with this - some of our existing sort codes might break if the public method names/parameters change, but people can either continue using older GRSIData versions or update their sort codes (besides, ROOT breaks things all the time). It may even be preferable to have the TIGRESS class inherit from GRIFFIN, since the arrays differ mainly by detector position and segmentation. Though it might be worth waiting until the 2026 shutdown to do any breaking changes, so that there aren't any surprises during experiment prep this year.