### PR TITLE
Small changes that came up during the preparation for S2418

### DIFF
--- a/include/TDemandHit.h
+++ b/include/TDemandHit.h
@@ -27,14 +27,20 @@ public:
 
 private:
    Int_t fFilter{0};
+   Int_t fCcShort{0}; ///< the short integration, long integration is stored in fCharge
+   Int_t fCcLong{0}; ///< this is actually the overflow bit of the energy!
 
 public:
    /////////////////////////  Setters  /////////////////////////////////////
    inline void SetFilterPattern(const int& x) { fFilter = x; }   //!<!
+   inline void SetCcShort(const int& x) { fCcShort = x; }        //!<!
+   inline void SetCcLong(const int& x) { fCcLong = x; }          //!<!
    // void SetHit();
 
    /////////////////////////  Getters  /////////////////////////////////////
    inline Int_t GetFilterPattern() const { return fFilter; }   //!<!
+   inline Int_t                 GetCcShort() const { return fCcShort; }        //!<!
+   inline Int_t                 GetCcLong() const { return fCcLong; }          //!<!
 
    /////////////////////////  TChannel Helpers /////////////////////////////////////
    bool InFilter(Int_t);   //!<!
@@ -50,7 +56,7 @@ private:
    Double_t GetDefaultDistance() const { return 0.0; }
 
    /// \cond CLASSIMP
-   ClassDefOverride(TDemandHit, 4);   // NOLINT(readability-else-after-return)
+   ClassDefOverride(TDemandHit, 5);   // NOLINT(readability-else-after-return)
    /// \endcond
 };
 /*! @} */

--- a/libraries/TGRSIAnalysis/TDemand/TDemandHit.cxx
+++ b/libraries/TGRSIAnalysis/TDemand/TDemandHit.cxx
@@ -16,6 +16,7 @@ TDemandHit::TDemandHit()
 TDemandHit::TDemandHit(const TDemandHit& rhs) : TDetectorHit(rhs)
 {
    Clear();
+
    rhs.Copy(*this);
 }
 
@@ -23,6 +24,10 @@ TDemandHit::TDemandHit(const TFragment& frag)
 {
    frag.Copy(*this);
    frag.CopyWave(*this);
+
+   SetCcShort(frag.GetCcShort());
+   SetCcLong(frag.GetCcLong());
+   
    /*if(TDemandHit::SetWave()) {
       if(frag.GetWaveform()->empty()) {
          std::cout << "Warning, TDemandHit::SetWave() set, but data waveform size is zero!" << std::endl;
@@ -40,6 +45,8 @@ void TDemandHit::Copy(TObject& rhs) const
    TDetectorHit::Copy(rhs);
    TDetectorHit::CopyWave(rhs);
    static_cast<TDemandHit&>(rhs).fFilter = fFilter;
+   static_cast<TDemandHit&>(rhs).fCcShort    = fCcShort;
+   static_cast<TDemandHit&>(rhs).fCcLong     = fCcLong;
 }
 
 void TDemandHit::Copy(TObject& rhs, bool waveform) const
@@ -61,6 +68,8 @@ void TDemandHit::Clear(Option_t* opt)
 {
    TDetectorHit::Clear(opt);   // clears the base (address, position and waveform)
    fFilter = 0;
+   fCcShort = 0;
+   fCcLong  = 0;
 }
 
 void TDemandHit::Print(Option_t*) const

--- a/libraries/TGRSIDataParser/TGRSIDataParser.cxx
+++ b/libraries/TGRSIDataParser/TGRSIDataParser.cxx
@@ -86,7 +86,7 @@ int TGRSIDataParser::Process(std::shared_ptr<TRawEvent> rawEvent)
             frags = CaenPhaToFragment(reinterpret_cast<uint32_t*>(ptr), banksize, event);
          } else {
             std::cout << DRED << std::endl
-                      << "Unknown bank in midas event #" << event->GetSerialNumber() << ", event ID 3, bank list " << event->GetBankList() << RESET_COLOR << std::endl;
+                      << "Unknown bank in midas event #" << event->GetSerialNumber() << ", event ID 3, bank list \"" << event->GetBankList() << "\"" << RESET_COLOR << std::endl;
          }
          break;
       case 4:

--- a/makefile
+++ b/makefile
@@ -202,7 +202,7 @@ html: all
 	@$(RM) tempfile.out
 
 clean:
-	@printf "\n$(WARN_COLOR)Cleaning up$(NO_COLOR)\n\n"
+	@printf "\n$(WARN_COLOR)Cleaning up GRSIData$(NO_COLOR)\n\n"
 	@-$(RM) -rf .build lib
 	@-$(RM) -f $(EXECUTABLES)
 	@-$(RM) -rf libraries/*.so libraries/*.pcm #this is here for cleaning up libraries from pre GRSI 3.0


### PR DESCRIPTION
DEMAND is now being read out via CAEN digitizers, so we've added CcShort and CcLong to `TDemandHit`. The former is the integration of the short gate, and the latter is the overflow bit of the energy/charge recorded. The integration of the long gate is stored in the charge member, accessed via `GetCharge` or `GetEnergy` (in the latter case any calibration parameters set in the .cal file are applied).
