### PR TITLE
TS3 proposed additions.

### DIFF
--- a/include/TS3.h
+++ b/include/TS3.h
@@ -53,20 +53,42 @@ public:
    {
       fFrontBackEnergy = de;
       SetPixels(false);
-   }   ///< Set fractional allowed energy difference
+   }   ///< Set allowed fractional energy difference
+   void SetFrontBackOffset(double de) // for backwards compatibility
+   {
+      SetFrontBackEOffset(de);
+   }   ///< Set front-back energy offset
    void SetFrontBackEOffset(double de)
    {
-      fFrontBackOffset = de;
+      fFrontBackEOffset = de;
       SetPixels(false);
-   }   ///< Set fractional allowed energy difference
+   }   ///< Set front-back energy offset
    void SetFrontBackTime(int time)
    {
       fFrontBackTime = time;
       SetPixels(false);
    }   ///< Set absolute allow time difference
+   void SetFrontBackTOffset(int dt)
+   {
+      fFrontBackTOffset = dt;
+      SetPixels(false);
+   } ///< Set absolute time offset
+
+   void UseFrontBackEAbs(bool opt)
+   {
+      fUseEAbs = opt;
+      SetPixels(false);
+   } ///< Use absolute energy differences
+   void SetFrontBackEnergyAbs(double de)
+   {
+      fFrontBackEnergyAbs = de;
+      SetPixels(false);
+   } ///< Set absolute allowed energy difference
+
    static Int_t  GetFrontBackTime() { return fFrontBackTime; }       //!<!
+   static Int_t GetFrontBackTOffset() { return fFrontBackTOffset; }   //!<!
    static double GetFrontBackEnergy() { return fFrontBackEnergy; }   //!<!
-   static double GetFrontBackOffset() { return fFrontBackOffset; }   //!<!
+   static double GetFrontBackEOffset() { return fFrontBackEOffset; }   //!<!
 
    TS3Hit* GetS3Hit(const int& i) const { return static_cast<TS3Hit*>(GetHit(i)); }
    TS3Hit* GetRingHit(const int& i);
@@ -149,9 +171,13 @@ private:
    static double fTargetDistance;   //!<!
 
    //In cfd units for historic reasons
-   static Int_t  fFrontBackTime;     //!<!
-   static double fFrontBackEnergy;   //!<!
-   static double fFrontBackOffset;   //!<!
+   static Int_t  fFrontBackTime;   //!<!
+   static Int_t  fFrontBackTOffset; //!<!
+   static double fFrontBackEnergyAbs; //!<!
+   static double fFrontBackEnergy; //!<!
+   static double fFrontBackEOffset; //!<!
+
+   static bool fUseEAbs; 
 
    /// \cond CLASSIMP
    ClassDefOverride(TS3, 4)   // NOLINT(readability-else-after-return)

--- a/include/TS3Hit.h
+++ b/include/TS3Hit.h
@@ -9,6 +9,7 @@
 #include "TFragment.h"
 #include "TDetectorHit.h"
 #include "TMnemonic.h"
+#include "TSRIM.h"
 
 class TS3Hit : public TDetectorHit {
 public:
@@ -23,6 +24,7 @@ public:
    Short_t GetRing() const { return fRing; }
    Short_t GetSector() const { return fSector; }
    Bool_t  GetIsDownstream() const { return fIsDownstream; }
+   Bool_t  GetIsSRIMSet() const { return fIsSRIMSet; }
    Int_t   GetArrayPosition() const
    {
       if(GetChannel() != nullptr) {
@@ -50,6 +52,7 @@ public:
    void SetRingNumber(Short_t rn) { fRing = rn; }
    void SetSectorNumber(Short_t sn) { fSector = sn; }
    void SetIsDownstream(Bool_t dwnstrm) { fIsDownstream = dwnstrm; }
+   void SetIsSRIMSet(Bool_t srm) { fIsSRIMSet = srm; }
 
    void SetRingNumber(TFragment& frag) { fRing = frag.GetSegment(); }
    void SetSectorNumber(TFragment& frag) { fSector = frag.GetSegment(); }
@@ -57,6 +60,14 @@ public:
    void SetSectorNumber() { fSector = GetSegment(); }
    void SetSectorNumber(int n) { fSector = n; }
    void SetRingNumber(int n) { fRing = n; }
+
+   void SetEDiff(double de) { fEDiff = de; }
+   Double_t GetEDiff() { return fEDiff; }
+   void SetTDiff(double dt) { fTDiff = dt; }
+   Double_t GetTDiff() { return fTDiff; }
+
+   void SetSRIMTable(TSRIM* srimTable);
+   Double_t GetCorrectedEnergy(double s3DL);
 
    void SetWavefit(const TFragment&);
    void SetTimeFit(Double_t time) { fTimeFit = time; }
@@ -69,8 +80,8 @@ public:
    Double_t GetTheta(double offset = 0, TVector3* vec = nullptr) const
    {
       if(vec == nullptr) {
-         vec = new TVector3();
-         vec->SetXYZ(0, 0, 1);
+         TVector3 beam(0, 0, 1); // allocate on stack to avoid memory leak
+         return GetPosition(offset).Angle(beam);
       }
       return GetPosition(offset).Angle(*vec);
    }
@@ -88,6 +99,11 @@ private:
    Bool_t  fIsDownstream{false};   // Downstream check
    Short_t fRing{0};               // front
    Short_t fSector{0};             // back
+   Double_t fEDiff{-10000}; // Front-back energy difference
+   Double_t fTDiff{-10000}; // Front-back time difference
+   
+   Bool_t fIsSRIMSet{false}; // SRIM Table check
+   TSRIM* fSRIMTable{nullptr};
 
    Double_t fTimeFit{0.};
    Double_t fSig2Noise{0.};

--- a/libraries/TGRSIAnalysis/TS3/TS3.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3.cxx
@@ -19,9 +19,13 @@ double TS3::fTargetDistance = 31.;
 // Default tigress unpacking settings
 TTransientBits<UShort_t> TS3::fGlobalS3Bits = TTransientBits<UShort_t>(static_cast<std::underlying_type_t<TS3::ES3GlobalBits>>(TS3::ES3GlobalBits::kMultHit));
 
-Int_t  TS3::fFrontBackTime   = 75;
+Int_t  TS3::fFrontBackTime = 75;
+Int_t  TS3::fFrontBackTOffset = 0;
 double TS3::fFrontBackEnergy = 0.9;
-double TS3::fFrontBackOffset = 0;
+double TS3::fFrontBackEOffset = 0;
+
+bool TS3::fUseEAbs = false;
+double TS3::fFrontBackEnergyAbs = 400; // keV
 
 TS3::TS3()
 {
@@ -104,7 +108,7 @@ void TS3::BuildPixels()
    if(!fS3Bits.TestBit(ES3Bits::kPixelsSet)) {
       fS3PixelHits.clear();
    }
-
+	
    if(fS3RingHits.empty() || fS3SectorHits.empty()) {
       return;
    }
@@ -113,10 +117,8 @@ void TS3::BuildPixels()
 
       // We are going to want energies several times
       // So build a quick vector
-      std::vector<double> EneR;
-      std::vector<double> EneS;
-      std::vector<bool>   UsedRing;
-      std::vector<bool>   UsedSector;
+      std::vector<double> EneR, EneS;
+      std::vector<bool>   UsedRing, UsedSector;
       for(auto& fS3RingHit : fS3RingHits) {
          EneR.push_back(fS3RingHit.GetEnergy());
          UsedRing.push_back(false);
@@ -130,20 +132,33 @@ void TS3::BuildPixels()
       /// Loop over two vectors and build energy+time matching hits
       for(size_t i = 0; i < fS3RingHits.size(); ++i) {
          for(size_t j = 0; j < fS3SectorHits.size(); ++j) {
-            if(fS3RingHits[i].GetArrayPosition() != fS3SectorHits[j].GetArrayPosition()) { continue; }
+	         if(fS3RingHits[i].GetArrayPosition()!=fS3SectorHits[j].GetArrayPosition()) continue;
 
-            if(abs(fS3RingHits[i].GetTime() - fS3SectorHits[j].GetTime()) * 1.6 < fFrontBackTime) {   // check time
-               if((EneR[i] - fFrontBackOffset) * fFrontBackEnergy < EneS[j] &&
-                  (EneS[j] - fFrontBackOffset) * fFrontBackEnergy < EneR[i]) {   // if time is good check energy
+            if(abs(fS3RingHits[i].GetTime() - fS3SectorHits[j].GetTime() + fFrontBackTOffset)*1.6 < fFrontBackTime) { // check time
+
+               bool goodE = false; // if time is good check energy
+               if(fUseEAbs == false){ // Use fractional energy 
+                  if((EneR[i] - fFrontBackEOffset) * fFrontBackEnergy < EneS[j] &&
+                     (EneS[j] - fFrontBackEOffset) * fFrontBackEnergy < EneR[i]) { goodE = true; }
+               }
+               else if(fUseEAbs == true){ // Use absolute energy
+                  if(abs(EneR[i] - EneS[j] - fFrontBackEOffset) < fFrontBackEnergyAbs) { goodE = true; }
+               }
+
+               if(goodE){ 
 
                   // Now we have accepted a good event, build it
                   if(SectorPreference()) {
-                     TS3Hit dethit = fS3SectorHits[j];   // Sector defines all data ring just gives position
+                     TS3Hit dethit = fS3SectorHits[j]; // Sector defines all data ring just gives position
                      dethit.SetRingNumber(fS3RingHits[i].GetRing());
+                     dethit.SetEDiff(EneR[i] - EneS[j]);
+                     dethit.SetTDiff(fS3RingHits[i].GetTime() - fS3SectorHits[j].GetTime());
                      fS3PixelHits.push_back(dethit);
                   } else {
-                     TS3Hit dethit = fS3RingHits[i];   // Ring defines all data sector just gives position (default)
+                     TS3Hit dethit = fS3RingHits[i]; // Ring defines all data sector just gives position (default)
                      dethit.SetSectorNumber(fS3SectorHits[j].GetSector());
+                     dethit.SetEDiff(EneR[i] - EneS[j]);
+                     dethit.SetTDiff(fS3RingHits[i].GetTime() - fS3SectorHits[j].GetTime());
                      fS3PixelHits.push_back(dethit);
                   }
 
@@ -185,18 +200,27 @@ void TS3::BuildPixels()
                   if(UsedSector.at(j)) {
                      continue;
                   }
-                  if(fS3RingHits[i].GetArrayPosition() != fS3SectorHits[j].GetArrayPosition()) { continue; }
-
+                  if(fS3RingHits[i].GetArrayPosition()!=fS3SectorHits[j].GetArrayPosition())continue;
+                  
                   for(size_t k = j + 1; k < fS3SectorHits.size(); ++k) {
                      if(UsedSector.at(k)) {
                         continue;
                      }
-                     if(fS3SectorHits[j].GetArrayPosition() != fS3SectorHits[k].GetArrayPosition()) { continue; }
+                     if(fS3SectorHits[j].GetArrayPosition()!=fS3SectorHits[k].GetArrayPosition()) continue;
 
-                     if(abs(fS3RingHits[i].GetTime() - fS3SectorHits[j].GetTime()) * 1.6 < fFrontBackTime &&
-                        abs(fS3RingHits[i].GetTime() - fS3SectorHits[k].GetTime()) * 1.6 < fFrontBackTime) {   // check time
-                        if((EneR[i] - fFrontBackOffset) * fFrontBackEnergy < (EneS[j] + EneS[k]) &&
-                           (EneS[j] + EneS[k] - fFrontBackOffset) * fFrontBackEnergy < EneR[i]) {   // if time is good check energy
+                     if(abs(fS3RingHits[i].GetTime() - fS3SectorHits[j].GetTime()  + fFrontBackTOffset)*1.6 < fFrontBackTime &&
+                        abs(fS3RingHits[i].GetTime() - fS3SectorHits[k].GetTime()  + fFrontBackTOffset)*1.6 < fFrontBackTime) { // check time
+
+                        bool goodE = false; // if time is good check energy
+                        if(fUseEAbs == false){ // Use fractional energy 
+                           if((EneR[i] - fFrontBackEOffset) * fFrontBackEnergy < (EneS[j] + EneS[k]) &&
+                              (EneS[j] + EneS[k] - fFrontBackEOffset) * fFrontBackEnergy < EneR[i]) { goodE = true; }
+                        }
+                        else if(fUseEAbs == true){ // Use absolute energy
+                           if(abs(EneR[i] - (EneS[j] + EneS[k]) - fFrontBackEOffset) < fFrontBackEnergyAbs) { goodE = true; }
+                        }
+
+                        if(goodE) { 
 
                            int SectorSep = fS3SectorHits[j].GetSector() - fS3SectorHits[k].GetSector();
                            if(abs(SectorSep) == 1 || abs(SectorSep) == fSectorNumber) {
@@ -206,27 +230,34 @@ void TS3::BuildPixels()
                               // sharing
 
                               if(KeepShared()) {
-                                 TS3Hit dethit = fS3RingHits[i];   // Ring defines all data sector just gives position
+                                 TS3Hit dethit = fS3RingHits[i]; // Ring defines all data sector just gives position
                                  // Selecting one of the sectors is currently the best class allows, some loss of
                                  // position information
                                  if(fS3SectorHits[k].GetEnergy() < fS3SectorHits[j].GetEnergy()) {
                                     dethit.SetSectorNumber(fS3SectorHits[j].GetSector());
+                                    dethit.SetTDiff(fS3RingHits[i].GetTime() - fS3SectorHits[j].GetTime());
                                  } else {
                                     dethit.SetSectorNumber(fS3SectorHits[k].GetSector());
+                                    dethit.SetTDiff(fS3RingHits[i].GetTime() - fS3SectorHits[k].GetTime());
                                  }
+                                 dethit.SetEDiff(EneR[i] - (EneS[j] + EneS[k]));
                                  fS3PixelHits.push_back(dethit);
                               }
                            } else {
                               // 2 separate hits with shared ring
 
                               // Now we have accepted a good event, build it
-                              TS3Hit dethit = fS3SectorHits[j];   // Sector now defines all data ring just gives position
+                              TS3Hit dethit = fS3SectorHits[j]; // Sector now defines all data ring just gives position
                               dethit.SetRingNumber(fS3RingHits[i].GetRing());
+                              dethit.SetEDiff(EneR[i] - EneS[j]);
+                              dethit.SetTDiff(fS3RingHits[i].GetTime() - fS3SectorHits[j].GetTime());
                               fS3PixelHits.push_back(dethit);
 
                               // Now we have accepted a good event, build it
-                              TS3Hit dethitB = fS3SectorHits[k];   // Sector now defines all data ring just gives position
+                              TS3Hit dethitB = fS3SectorHits[k]; // Sector now defines all data ring just gives position
                               dethitB.SetRingNumber(fS3RingHits[i].GetRing());
+                              dethitB.SetEDiff(EneR[i] - EneS[k]);
+                              dethitB.SetTDiff(fS3RingHits[i].GetTime() - fS3SectorHits[k].GetTime());
                               fS3PixelHits.push_back(dethitB);
                            }
 
@@ -237,7 +268,7 @@ void TS3::BuildPixels()
                      }
                   }
                }
-            }   // End Shared Ring loop
+            } // End Shared Ring loop
          }
 
          ringcount   = 0;
@@ -264,18 +295,27 @@ void TS3::BuildPixels()
                   if(UsedRing.at(j)) {
                      continue;
                   }
-                  if(fS3SectorHits[i].GetArrayPosition() != fS3RingHits[j].GetArrayPosition()) { continue; }
-
+                  if(fS3SectorHits[i].GetArrayPosition()!=fS3RingHits[j].GetArrayPosition())continue;
+		  
                   for(size_t k = j + 1; k < fS3RingHits.size(); ++k) {
                      if(UsedRing.at(k)) {
                         continue;
                      }
-                     if(fS3RingHits[j].GetArrayPosition() != fS3RingHits[k].GetArrayPosition()) { continue; }
+                     if(fS3RingHits[j].GetArrayPosition()!=fS3RingHits[k].GetArrayPosition())continue;
 
-                     if(abs(fS3SectorHits[i].GetTime() - fS3RingHits[j].GetTime()) * 1.6 < fFrontBackTime &&
-                        abs(fS3SectorHits[i].GetTime() - fS3RingHits[k].GetTime()) * 1.6 < fFrontBackTime) {   // first check time
-                        if((EneS[i] - fFrontBackOffset) * fFrontBackEnergy < (EneR[j] + EneR[k]) &&
-                           (EneR[j] + EneR[k] - fFrontBackOffset) * fFrontBackEnergy < EneS[i]) {   // if time is good check energy
+                     if(abs(fS3SectorHits[i].GetTime() - fS3RingHits[j].GetTime() + fFrontBackTOffset)*1.6 < fFrontBackTime &&
+                        abs(fS3SectorHits[i].GetTime() - fS3RingHits[k].GetTime() + fFrontBackTOffset)*1.6 < fFrontBackTime) { // first check time
+
+                        bool goodE = false; // if time is good check energy
+                        if(fUseEAbs == false){ // Use fractional energy 
+                           if((EneS[i] - fFrontBackEOffset) * fFrontBackEnergy < (EneR[j] + EneR[k]) &&
+                              (EneR[j] + EneR[k] - fFrontBackEOffset) * fFrontBackEnergy < EneS[i]) { goodE = true; }
+                        }
+                        else if(fUseEAbs == true){ // Use absolute energy
+                           if(abs((EneR[j] + EneR[k]) - EneS[i] - fFrontBackEOffset) < fFrontBackEnergyAbs) { goodE = true; }
+                        }
+
+                        if(goodE) { 
 
                            if(abs(fS3RingHits[j].GetRing() - fS3RingHits[k].GetRing()) == 1) {
                               // Same sector and neighbour rings, almost certainly charge sharing
@@ -284,28 +324,35 @@ void TS3::BuildPixels()
                               // sharing
 
                               if(KeepShared()) {
-                                 TS3Hit dethit = fS3SectorHits[i];   // Sector defines all data ring just gives position
+                                 TS3Hit dethit = fS3SectorHits[i]; // Sector defines all data ring just gives position
                                  // Selecting one of the sectors is currently the best class allows, some
                                  // loss of
                                  // position information
                                  if(fS3RingHits[k].GetEnergy() < fS3RingHits[j].GetEnergy()) {
                                     dethit.SetRingNumber(fS3RingHits[j].GetRing());
+                                    dethit.SetTDiff(fS3RingHits[j].GetTime() - fS3SectorHits[i].GetTime());
                                  } else {
                                     dethit.SetRingNumber(fS3RingHits[k].GetRing());
+                                    dethit.SetTDiff(fS3RingHits[k].GetTime() - fS3SectorHits[i].GetTime());
                                  }
+                                 dethit.SetEDiff((EneR[j] + EneR[k]) - EneS[i]);
                                  fS3PixelHits.push_back(dethit);
                               }
                            } else {
                               // 2 separate hits with shared sector
 
                               // Now we have accepted a good event, build it
-                              TS3Hit dethit = fS3RingHits[j];   // Ring defines all data sector just gives position
+                              TS3Hit dethit = fS3RingHits[j]; // Ring defines all data sector just gives position
                               dethit.SetSectorNumber(fS3SectorHits[i].GetSector());
+                              dethit.SetEDiff(EneR[j] - EneS[i]);
+                              dethit.SetTDiff(fS3RingHits[j].GetTime() - fS3SectorHits[i].GetTime());
                               fS3PixelHits.push_back(dethit);
 
                               // Now we have accepted a good event, build it
-                              TS3Hit dethitB = fS3RingHits[k];   // Ring defines all data sector just gives position
+                              TS3Hit dethitB = fS3RingHits[k]; // Ring defines all data sector just gives position
                               dethitB.SetSectorNumber(fS3SectorHits[i].GetSector());
+                              dethitB.SetEDiff(EneR[k] - EneS[i]);
+                              dethitB.SetTDiff(fS3RingHits[k].GetTime() - fS3SectorHits[i].GetTime());
                               fS3PixelHits.push_back(dethitB);
                            }
 
@@ -316,7 +363,7 @@ void TS3::BuildPixels()
                      }
                   }
                }
-            }   // End Shared Sector loop
+            } // End Shared Sector loop
          }
       }
 

--- a/libraries/TGRSIAnalysis/TS3/TS3Hit.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3Hit.cxx
@@ -38,6 +38,10 @@ void TS3Hit::Copy(TObject& rhs) const
    static_cast<TS3Hit&>(rhs).fIsDownstream = fIsDownstream;
    static_cast<TS3Hit&>(rhs).fTimeFit      = fTimeFit;
    static_cast<TS3Hit&>(rhs).fSig2Noise    = fSig2Noise;
+	static_cast<TS3Hit&>(rhs).fEDiff        = fEDiff;
+	static_cast<TS3Hit&>(rhs).fTDiff        = fTDiff;
+   static_cast<TS3Hit&>(rhs).fIsSRIMSet    = fIsSRIMSet;
+	static_cast<TS3Hit&>(rhs).fSRIMTable    = fSRIMTable;
 }
 
 void TS3Hit::Copy(TObject& rhs, bool waveform) const
@@ -54,6 +58,10 @@ void TS3Hit::Clear(Option_t* opt)
    fRing         = -1;
    fSector       = -1;
    fIsDownstream = false;
+	fEDiff        = -10000;
+	fTDiff        = -10000;
+   fIsSRIMSet    = false;
+	fSRIMTable    = nullptr;
 }
 
 void TS3Hit::SetWavefit(const TFragment& frag)
@@ -142,4 +150,25 @@ Double_t TS3Hit::GetDefaultDistance() const
    }
 
    return z;
+}
+
+void TS3Hit::SetSRIMTable(TSRIM* srimTable)
+{
+	fSRIMTable = srimTable;
+	SetIsSRIMSet(true);
+}
+
+Double_t TS3Hit::GetCorrectedEnergy(double s3DL)
+{
+  if(!GetIsSRIMSet()){
+		std::cerr<<"Error in TS3Hit::GetCorrectedEnergy - Please load SRIMTable"<<std::endl;
+		return -1;
+	}
+
+	TVector3 vec(0, 0, -1); // S3 is at backward angles w.r.t beam axis. 
+												  // z=-1 to get correct positive angles of rings.
+	double theta = GetTheta(0, &vec);
+	double eCor = GetEnergy() + fSRIMTable->GetEnergyLost(GetEnergy(), s3DL/TMath::Cos(theta));
+	
+	return eCor;
 }


### PR DESCRIPTION
 S3Hit can now be provided with a TSRIM file and then calculate the energy with dead layer correction. Absolute energy window and time offset can be used when building s3 pixels from the front-back (sector-ring). By default the fractional energy window is used. I also write the energy and time difference to the s3hit so they can be checked after the pixel is built.